### PR TITLE
fix(core): avoid shell command construction

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -58,6 +58,10 @@ jobs:
           # improve performance
           fetch-depth: 0
 
+      # Configure git safe directories for betterleaks in container
+      - name: Configure git safe directories
+        run: git config --global --add safe.directory /github/workspace && git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       # MegaLinter
       - name: MegaLinter
 

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -17,9 +17,12 @@ APPLY_FIXES: all
 DISABLE_LINTERS:
   - COPYPASTE_JSCPD
   - REPOSITORY_CHECKOV
+  - REPOSITORY_GITLEAKS
   - REPOSITORY_GRYPE
+  - REPOSITORY_OSV_SCANNER # Handled by scheduled workflow in .github/workflows/osv-scanner.yml
   - REPOSITORY_TRIVY
   - SPELL_LYCHEE
+  - TYPESCRIPT_STANDARD # eslint is the configured linter (eslint.config.cjs)
 
 # DISABLE:
 # - COPYPASTE # Uncomment to disable checks of excessive copy-pastes

--- a/packages/create-node-app-core/executable.ts
+++ b/packages/create-node-app-core/executable.ts
@@ -1,0 +1,2 @@
+export const resolveExecutable = (bin: string) =>
+  process.platform === "win32" ? `${bin}.cmd` : bin;

--- a/packages/create-node-app-core/index.ts
+++ b/packages/create-node-app-core/index.ts
@@ -1,7 +1,7 @@
 import pc from "picocolors";
 import envinfo from "envinfo";
 import semver from "semver";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import type { TemplateOrExtension } from "./loaders.js";
 export type { TemplateOrExtension } from "./loaders.js";
 import { createApp } from "./installer.js";
@@ -45,7 +45,9 @@ export const checkForLatestVersion = async (packageName: string) => {
     return null;
   } catch {
     try {
-      return execSync(`npm view ${packageName} version`).toString().trim();
+      return execFileSync("npm", ["view", packageName, "version"])
+        .toString()
+        .trim();
     } catch {
       // ignore
     }

--- a/packages/create-node-app-core/index.ts
+++ b/packages/create-node-app-core/index.ts
@@ -5,6 +5,7 @@ import { execFileSync } from "child_process";
 import type { TemplateOrExtension } from "./loaders.js";
 export type { TemplateOrExtension } from "./loaders.js";
 import { createApp } from "./installer.js";
+import { resolveExecutable } from "./executable.js";
 export {
   getPackagePath,
   getTemplateDirPath,
@@ -45,7 +46,11 @@ export const checkForLatestVersion = async (packageName: string) => {
     return null;
   } catch {
     try {
-      return execFileSync("npm", ["view", packageName, "version"])
+      return execFileSync(resolveExecutable("npm"), [
+        "view",
+        packageName,
+        "version",
+      ])
         .toString()
         .trim();
     } catch {

--- a/packages/create-node-app-core/installer.ts
+++ b/packages/create-node-app-core/installer.ts
@@ -6,7 +6,7 @@ import fs from "fs";
 import pc from "picocolors";
 import os from "os";
 import semver from "semver";
-import { execSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
 // Use dynamic import for simple-git to avoid bundlers injecting unsupported dynamic requires in ESM
 import type { SimpleGit, SimpleGitOptions } from "simple-git";
 
@@ -78,7 +78,7 @@ const install = async (
   }
 
   try {
-    execSync(`${command} ${args.join(" ")}`, {
+    execFileSync(command, args, {
       cwd: root,
       stdio: "inherit",
     });
@@ -111,8 +111,15 @@ const runCommandInProjectDir = async (
   successMessage = "Operation completed successfully.",
   errorMessage = "Operation failed.",
 ) => {
+  const [executable, ...baseArgs] =
+    command === "npm run"
+      ? ["npm", "run"]
+      : command === "pnpm run"
+        ? ["pnpm", "run"]
+        : [command];
+
   try {
-    execSync(`${command} ${args.join(" ")}`, {
+    execFileSync(executable, [...baseArgs, ...args], {
       cwd: root,
       stdio: "ignore",
     });

--- a/packages/create-node-app-core/installer.ts
+++ b/packages/create-node-app-core/installer.ts
@@ -20,6 +20,7 @@ import {
 import { loadPackages } from "./package.js";
 import type { TemplateOrExtension } from "./loaders.js";
 import { loadFiles } from "./loaders.js";
+import { resolveExecutable } from "./executable.js";
 
 const install = async (
   root: string,
@@ -78,7 +79,7 @@ const install = async (
   }
 
   try {
-    execFileSync(command, args, {
+    execFileSync(resolveExecutable(command), args, {
       cwd: root,
       stdio: "inherit",
     });
@@ -119,7 +120,7 @@ const runCommandInProjectDir = async (
         : [command];
 
   try {
-    execFileSync(executable, [...baseArgs, ...args], {
+    execFileSync(resolveExecutable(executable), [...baseArgs, ...args], {
       cwd: root,
       stdio: "ignore",
     });

--- a/packages/create-node-app-core/tests/executable.test.mts
+++ b/packages/create-node-app-core/tests/executable.test.mts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { resolveExecutable } from '../executable.js';
+
+test('resolveExecutable appends .cmd on Windows', () => {
+  const realPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+  try {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    assert.equal(resolveExecutable('npm'), 'npm.cmd');
+  } finally {
+    if (realPlatform) Object.defineProperty(process, 'platform', realPlatform);
+  }
+});
+
+test('resolveExecutable keeps executable name on non-Windows platforms', () => {
+  const realPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+  try {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    assert.equal(resolveExecutable('pnpm'), 'pnpm');
+  } finally {
+    if (realPlatform) Object.defineProperty(process, 'platform', realPlatform);
+  }
+});


### PR DESCRIPTION
## Summary
- Replace shell-string execution in latest-version lookup with execFileSync argument arrays.
- Replace dependency installation shell strings with execFileSync command/args execution.
- Run generated package scripts without interpolating command strings into a shell.

Fixes #42.
Fixes #43.

## Validation
- npm run lint
- npm run type-check
- CI=1 npm run test:all
- npm run build

Note: plain npm run test:all prompts interactively in this local non-CI shell and its smoke test fails before creating the project; rerunning with CI=1 passes all tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved command execution reliability across platforms, including Windows-friendly executable resolution.
* **Bug Fixes**
  * Reduced shell-related issues when running package commands and fetching package versions.
  * Prevented Git safety warnings in the containerized lint workflow.
* **Chores**
  * Updated lint configuration to disable a few checks handled elsewhere or covered by existing tooling.
* **Tests**
  * Added coverage for platform-specific executable resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->