### PR TITLE
fix: improve template errors, --set parsing, and project docs

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [ulises-jeremias]

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -19,9 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .node-version
           cache: npm

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -20,10 +20,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-      - name: Setup Danger Files
-        run: |
-          echo "Setting up Danger files...";
-          mv tools/danger/* .
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -35,6 +31,9 @@ jobs:
         run: npm run lint --workspaces --if-present
       - name: Type Check
         run: npm run type-check --if-present
+      - name: Install Danger
+        run: npm ci
+        working-directory: tools/danger
       - name: Danger JS Action
         uses: actions/github-script@v7
         env:
@@ -42,4 +41,4 @@ jobs:
         with:
           script: |
             const { execSync } = require('node:child_process');
-            execSync('npx danger ci', { stdio: 'inherit' });
+            execSync('npx danger ci --dangerfile tools/danger/dangerfile.ts', { stdio: 'inherit' });

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -34,11 +34,8 @@ jobs:
       - name: Install Danger
         run: npm ci
         working-directory: tools/danger
-      - name: Danger JS Action
-        uses: actions/github-script@v7
+      - name: Danger
+        run: npx danger ci
+        working-directory: tools/danger
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          script: |
-            const { execSync } = require('node:child_process');
-            execSync('npx danger ci --dangerfile tools/danger/dangerfile.ts', { stdio: 'inherit' });

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ Pick a template. Layer addons. Ship production-ready code in minutes.</p>
 [![npm][npmversion]][npmurl]
 [![npm][npmdownloads]][npmurl]
 [![License: MIT][licensebadge]][licenseurl]
+[![GitHub Sponsors](https://img.shields.io/github/sponsors/ulises-jeremias?style=flat&logo=github)](https://github.com/sponsors/ulises-jeremias)
 [![Coverage](./.github/badges/coverage.svg)](#-available-scripts)
 
-[Changelog](./packages/create-awesome-node-app/CHANGELOG.md) · [Contributing](./CONTRIBUTING.md) · [**🌐 Official Site**](https://create-awesome-node-app.vercel.app)
+[Changelog](./packages/create-awesome-node-app/CHANGELOG.md) · [Contributing](./CONTRIBUTING.md) · [Troubleshooting](./docs/TROUBLESHOOTING.md) · [Migration](./docs/MIGRATION.md) · [**🌐 Official Site**](https://create-awesome-node-app.vercel.app)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This repository contains the source code for the [`create-awesome-node-app`](htt
 This is a **monorepo** managed with npm workspaces and [Turborepo](https://turbo.build/):
 
 | Package                                                         | Description                                                  |
-| --------------------------------------------------------------- | ------------------------------------------------------------ |
+|-----------------------------------------------------------------|--------------------------------------------------------------|
 | [`create-awesome-node-app`](./packages/create-awesome-node-app) | The main CLI — Commander-based, interactive + CI-friendly    |
 | [`@create-node-app/core`](./packages/create-node-app-core)      | Core generation logic (template loading, git, package merge) |
 | `@create-node-app/eslint-config*`                               | Shared ESLint presets (base, TypeScript, React, Next.js)     |
@@ -157,7 +157,7 @@ npx create-awesome-node-app debug-app -t react-vite-boilerplate --verbose
 ### Template Catalog Reference (Excerpt)
 
 | Slug                              | Description                          |
-| --------------------------------- | ------------------------------------ |
+|-----------------------------------|--------------------------------------|
 | `react-vite-boilerplate`          | React + Vite + TypeScript + Router   |
 | `nextjs-starter`                  | Production-ready Next.js starter     |
 | `nestjs-boilerplate`              | Scalable NestJS backend              |
@@ -172,7 +172,7 @@ Full catalog: **[create-awesome-node-app.vercel.app/templates](https://create-aw
 ### Popular Extensions (React)
 
 | Slug           | Purpose                               |
-| -------------- | ------------------------------------- |
+|----------------|---------------------------------------|
 | `tailwind-css` | Tailwind CSS utility-first styling    |
 | `zustand`      | Lightweight state management          |
 | `react-query`  | Async server state (TanStack Query)   |
@@ -185,7 +185,7 @@ Full catalog: **[create-awesome-node-app.vercel.app/templates](https://create-aw
 ## 📋 Available Scripts
 
 | `npm run <script>` | Description                                   |
-| ------------------ | --------------------------------------------- |
+|--------------------|-----------------------------------------------|
 | `test`             | Run unit tests with Node's native test runner |
 | `lint`             | Lint the project with ESLint                  |
 | `lint:fix`         | Lint and auto-fix correctable errors          |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| 0.8.x   | ✅        |
+| < 0.8   | ❌        |
+
+## Reporting a Vulnerability
+
+Use GitHub [Security Advisories](https://github.com/Create-Node-App/create-node-app/security/advisories/new) to report vulnerabilities privately.
+
+**Do not** open a public issue for security vulnerabilities.
+
+### Response SLA
+
+- **Acknowledgment:** within 48 hours
+- **Triage:** within 7 days
+- **Patch release:** within 30 days for critical/high severity
+
+## Scope
+
+- CLI tool (`create-awesome-node-app`)
+- Core package (`@create-node-app/core`)
+- Generated project templates are maintained in [cna-templates](https://github.com/Create-Node-App/cna-templates); report template issues there unless they affect the CLI itself

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,9 +3,9 @@
 ## Supported Versions
 
 | Version | Supported |
-| ------- | --------- |
-| 0.8.x   | ✅        |
-| < 0.8   | ❌        |
+|---------|-----------|
+| 0.8.x   | ✅         |
+| < 0.8   | ❌         |
 
 ## Reporting a Vulnerability
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,72 @@
+# Migration Guide
+
+How to keep a scaffolded project aligned with improvements in `create-awesome-node-app` and [cna-templates](https://github.com/Create-Node-App/cna-templates).
+
+## Why migration is hard
+
+`create-awesome-node-app` generates a **one-time snapshot** of a template plus extensions. After scaffolding, the CLI does not maintain a live link to your project. You own every file and dependency choice going forward.
+
+That is by design — generated projects should be independent — but it means updates require deliberate effort.
+
+## Strategy 1: Manual dependency updates
+
+1. Run `npm outdated` (or `pnpm outdated` / `yarn outdated`) in your project.
+2. Enable Dependabot if you used the `all-github-setup` extension (see its workflow in cna-templates).
+3. Compare your `package.json` scripts and devDependencies with the current template in [cna-templates](https://github.com/Create-Node-App/cna-templates/tree/main/templates).
+
+## Strategy 2: Diff against a fresh scaffold
+
+Scaffold a new project with the same template and extensions, then diff:
+
+```bash
+npx create-awesome-node-app my-project-new \
+  -t <template-slug> \
+  --addons <extension-slugs> \
+  --no-install
+
+diff -r my-project/ my-project-new/ \
+  --exclude=node_modules \
+  --exclude=.git \
+  --exclude=dist \
+  --exclude=.next
+```
+
+Review differences in config files (`eslint.config.mjs`, `tsconfig.json`, CI workflows) and port changes selectively.
+
+## Strategy 3: Selective re-scaffolding
+
+For a single extension update:
+
+1. Scaffold a throwaway project with only that extension applied.
+2. Copy the extension-specific files into your existing project (e.g. Drizzle schema, auth routes).
+3. Merge `package.json` dependency changes manually.
+
+## CLI version changelog
+
+Track releases for template and extension changes:
+
+- [create-node-app releases](https://github.com/Create-Node-App/create-node-app/releases)
+- [cna-templates releases](https://github.com/Create-Node-App/cna-templates/releases)
+
+When upgrading the CLI globally:
+
+```bash
+npm install -g create-awesome-node-app@latest
+# or prefer npx without global install:
+npx create-awesome-node-app@latest --help
+```
+
+## Adding extensions to an existing project
+
+There is no `cna add-extension` command yet. To add an extension after the fact:
+
+1. Browse the extension in [cna-templates/extensions](https://github.com/Create-Node-App/cna-templates/tree/main/extensions).
+2. Read the extension README for required files and dependencies.
+3. Scaffold a minimal project with that extension and copy the relevant files.
+4. Install matching dependencies from the extension's `package.json`.
+
+## Getting help
+
+- [Troubleshooting](./TROUBLESHOOTING.md)
+- [GitHub Issues](https://github.com/Create-Node-App/create-node-app/issues)
+- [Discussions](https://github.com/Create-Node-App/cna-templates/discussions)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,87 @@
+# Troubleshooting
+
+Common issues when scaffolding projects with `create-awesome-node-app`.
+
+## Windows path issues ([#30](https://github.com/Create-Node-App/create-node-app/issues/30))
+
+**Symptoms:** Scaffolding fails on Windows with path-related errors, or files are created in unexpected locations.
+
+**Workarounds:**
+
+- Run the CLI from PowerShell or Git Bash with administrator privileges if permission errors appear.
+- Prefer short project paths without spaces (e.g. `C:\dev\my-app`).
+- Use WSL2 for the most reliable experience on Windows.
+
+**Status:** Under investigation. Track progress in issue #30.
+
+## ESLint "Unexpected token" error ([#63](https://github.com/Create-Node-App/create-node-app/issues/63))
+
+**Symptoms:** After scaffolding, `npm run lint` fails with `Unexpected token` in config or source files.
+
+**Cause:** Usually ESLint flat config (v9+) compatibility — the parser may not match the file type being linted.
+
+**Fix:**
+
+1. Open `eslint.config.mjs` (or `.eslintrc`) in the generated project.
+2. Confirm `@eslint/js` and `typescript-eslint` versions match the template's `package.json`.
+3. Run `npm run lint:fix` if available, then `npm run lint` again.
+4. If the error points at a specific file, check that the correct parser (`@typescript-eslint/parser`) is applied to `.ts`/`.tsx` files.
+
+## Node.js version mismatch
+
+**Symptoms:** The CLI exits immediately with a Node version error.
+
+**Requirement:** Node.js **>= 22.0.0**
+
+```bash
+node --version
+```
+
+**Switch versions:**
+
+- [nvm](https://github.com/nvm-sh/nvm): `nvm install 22 && nvm use 22`
+- [fnm](https://github.com/Schniz/fnm): `fnm install 22 && fnm use 22`
+- [Volta](https://volta.sh/): `volta install node@22`
+
+## File permission errors ([#29](https://github.com/Create-Node-App/create-node-app/issues/29))
+
+**Symptoms:** Generated files have incorrect permissions on macOS/Linux; scripts are not executable.
+
+**Workaround:**
+
+```bash
+chmod -R u+rwX my-project
+```
+
+**Status:** Under investigation. Track progress in issue #29.
+
+## Template URL not found
+
+**Symptoms:** Scaffolding fails with a message about HTTP 404 or repository not found.
+
+**Tips:**
+
+- Registry templates use slugs: `npx create-awesome-node-app my-app -t nextjs-starter`
+- Custom URLs must be valid GitHub URLs or `file://` paths for local development
+- List official templates: `npx create-awesome-node-app --list-templates`
+- Test a local template: `npx create-awesome-node-app my-app -t "file:///path/to/cna-templates?subdir=templates/react-vite-starter"`
+
+## Package manager conflicts
+
+**Symptoms:** Install fails, lockfile conflicts, or wrong package manager is used.
+
+**Guidance:**
+
+- The CLI supports `npm` (default), `yarn`, and `pnpm` via `--use-yarn` / `--use-pnpm`
+- After generation, stick to one package manager — do not mix `package-lock.json` and `pnpm-lock.yaml`
+- If you switch managers, delete `node_modules` and the other lockfile before reinstalling
+
+## `--set` values with spaces
+
+When passing custom options that contain spaces, quote the entire `key=value` pair:
+
+```bash
+npx create-awesome-node-app my-app -t nextjs-starter --set 'projectName=My Awesome Project'
+```
+
+See also: [MIGRATION.md](./MIGRATION.md) for keeping scaffolded projects up to date.

--- a/packages/create-awesome-node-app/src/index.ts
+++ b/packages/create-awesome-node-app/src/index.ts
@@ -8,6 +8,7 @@ import {
   type TemplateOrExtension,
 } from "@create-node-app/core";
 import { getCnaOptions } from "./options.js";
+import { parseSetOverrides } from "./set-overrides.js";
 // NodeNext JSON import with import attributes
 import packageJson from "../package.json" with { type: "json" };
 import { listTemplates, listAddons } from "./list.js";
@@ -56,7 +57,7 @@ const main = async () => {
     .option("--list-addons", "list all available addons")
     .option(
       "--set <assignments...>",
-      "set a custom template option (format: key=value, repeatable)",
+      "set a custom template option (format: key=value; quote values with spaces: --set 'name=My App')",
     )
     .action((providedProjectName: string | undefined) => {
       projectName = providedProjectName || projectName;
@@ -97,18 +98,8 @@ const main = async () => {
   const { useYarn, usePnpm, set, ...restOpts } = opts;
   const packageManager = useYarn ? "yarn" : usePnpm ? "pnpm" : "npm";
 
-  // Parse --set key=value assignments into an overrides map
-  const setOverrides: Record<string, string> = {};
-  if (Array.isArray(set)) {
-    for (const assignment of set as string[]) {
-      const eqIdx = assignment.indexOf("=");
-      if (eqIdx > 0) {
-        setOverrides[assignment.slice(0, eqIdx).trim()] = assignment.slice(
-          eqIdx + 1,
-        );
-      }
-    }
-  }
+  // Parse --set key=value assignments into an overrides map.
+  const setOverrides = parseSetOverrides(set as string[] | undefined);
 
   const templatesOrExtensions: TemplateOrExtension[] = [restOpts.template]
     .concat(Array.isArray(restOpts.extend) ? restOpts.extend : [])

--- a/packages/create-awesome-node-app/src/set-overrides.ts
+++ b/packages/create-awesome-node-app/src/set-overrides.ts
@@ -1,0 +1,44 @@
+const unquoteSetValue = (value: string): string => {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+};
+
+/**
+ * Parse --set key=value assignments into an overrides map.
+ * Commander may split values containing spaces into multiple argv tokens;
+ * rejoin segments that lack '=' with the previous assignment.
+ */
+export const parseSetOverrides = (
+  set: string[] | undefined,
+): Record<string, string> => {
+  const setOverrides: Record<string, string> = {};
+
+  if (!Array.isArray(set)) {
+    return setOverrides;
+  }
+
+  const assignments: string[] = [];
+  for (const part of set) {
+    if (part.includes("=") || assignments.length === 0) {
+      assignments.push(part);
+    } else {
+      assignments[assignments.length - 1] += ` ${part}`;
+    }
+  }
+
+  for (const assignment of assignments) {
+    const eqIdx = assignment.indexOf("=");
+    if (eqIdx > 0) {
+      setOverrides[assignment.slice(0, eqIdx).trim()] = unquoteSetValue(
+        assignment.slice(eqIdx + 1).trim(),
+      );
+    }
+  }
+
+  return setOverrides;
+};

--- a/packages/create-awesome-node-app/tests/set-overrides.test.mts
+++ b/packages/create-awesome-node-app/tests/set-overrides.test.mts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { parseSetOverrides } from "../src/set-overrides.js";
+
+test("parseSetOverrides handles simple key=value pairs", () => {
+  assert.deepEqual(parseSetOverrides(["projectName=my-app", "author=Jane"]), {
+    projectName: "my-app",
+    author: "Jane",
+  });
+});
+
+test("parseSetOverrides rejoins values split across argv tokens", () => {
+  assert.deepEqual(
+    parseSetOverrides(["projectName=My", "Awesome", "Project"]),
+    { projectName: "My Awesome Project" },
+  );
+});
+
+test("parseSetOverrides strips surrounding quotes", () => {
+  assert.deepEqual(parseSetOverrides(['projectName="My Awesome Project"']), {
+    projectName: "My Awesome Project",
+  });
+});
+
+test("parseSetOverrides returns empty object for undefined input", () => {
+  assert.deepEqual(parseSetOverrides(undefined), {});
+});

--- a/packages/create-node-app-core/git.ts
+++ b/packages/create-node-app-core/git.ts
@@ -7,6 +7,32 @@ import * as fse from "fs-extra"; // Import fs-extra for advanced file operations
 
 const log = debug("cna:git");
 
+const formatRepositoryDownloadError = (error: unknown, url: string): string => {
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (/not found|404|repository not found/i.test(message)) {
+    return [
+      `Error: Could not fetch template from '${url}'.`,
+      "  → The URL returned HTTP 404 or the repository was not found. Please verify the URL is correct.",
+      "  → Run 'npx create-awesome-node-app --list-templates' to see available templates.",
+    ].join("\n");
+  }
+
+  if (/403|authentication|permission denied|access denied/i.test(message)) {
+    return [
+      `Error: Could not fetch template from '${url}'.`,
+      "  → Access denied (HTTP 403). Check that the repository is public or you have access.",
+      "  → Run 'npx create-awesome-node-app --list-templates' to see available templates.",
+    ].join("\n");
+  }
+
+  return [
+    `Error: Could not fetch template from '${url}'.`,
+    `  → ${message}`,
+    "  → Run 'npx create-awesome-node-app --list-templates' to see available templates.",
+  ].join("\n");
+};
+
 /**
  * filter .git folder
  */
@@ -117,7 +143,7 @@ export const downloadRepository = async ({
       // Mark the targetId as completed
       completedTargetIds.set(id, true);
     } catch (error) {
-      console.error("Error during repository download:", error);
+      throw new Error(formatRepositoryDownloadError(error, gitUrl));
     } finally {
       // Remove the promise from the map when the operation is complete
       gitOperationMap.delete(id);

--- a/packages/create-node-app-core/paths.ts
+++ b/packages/create-node-app-core/paths.ts
@@ -111,7 +111,7 @@ const solveTemplateOrExtensionPath = async (
   try {
     parsed = solveValuesFromTemplateOrExtensionUrl(templateOrExtension);
   } catch {
-    // Fallback to an internal templatesOrExtensions directory (legacy behaviour)
+    // Fallback to an internal templatesOrExtensions directory (legacy behavior)
     return {
       dir: path.resolve(
         moduleDir,

--- a/packages/create-node-app-core/paths.ts
+++ b/packages/create-node-app-core/paths.ts
@@ -1,7 +1,13 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
+import { fileURLToPath } from "url";
 import { downloadRepository } from "./git.js";
+
+const moduleDir =
+  typeof __dirname !== "undefined"
+    ? __dirname
+    : path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Parse a template / extension URL (supports GitHub style and file:// URLs).
@@ -81,16 +87,12 @@ const solveRepositoryPath = async ({
     return { dir: target, subdir };
   }
 
-  try {
-    await downloadRepository({
-      url,
-      branch: branch || "",
-      target,
-      targetId,
-    });
-  } catch {
-    // Ignore git error
-  }
+  await downloadRepository({
+    url,
+    branch: branch || "",
+    target,
+    targetId,
+  });
 
   return { dir: target, subdir };
 };
@@ -105,23 +107,14 @@ type SolvedTemplatePath = {
 const solveTemplateOrExtensionPath = async (
   templateOrExtension: string,
 ): Promise<SolvedTemplatePath> => {
+  let parsed: ReturnType<typeof solveValuesFromTemplateOrExtensionUrl>;
   try {
-    const { url, branch, subdir, protocol, pathname, ignorePackage } =
-      solveValuesFromTemplateOrExtensionUrl(templateOrExtension);
-
-    if (protocol === "file:") {
-      // Already parsed absolute path in pathname
-      const baseDir = pathname;
-      return { dir: baseDir, subdir, ignorePackage };
-    }
-
-    const gitData = await solveRepositoryPath({ url, branch, subdir });
-    return { dir: gitData.dir, subdir: gitData.subdir, ignorePackage };
+    parsed = solveValuesFromTemplateOrExtensionUrl(templateOrExtension);
   } catch {
     // Fallback to an internal templatesOrExtensions directory (legacy behaviour)
     return {
       dir: path.resolve(
-        __dirname,
+        moduleDir,
         "..",
         "templatesOrExtensions",
         templateOrExtension,
@@ -130,6 +123,15 @@ const solveTemplateOrExtensionPath = async (
       ignorePackage: undefined,
     };
   }
+
+  const { url, branch, subdir, protocol, pathname, ignorePackage } = parsed;
+
+  if (protocol === "file:") {
+    return { dir: pathname, subdir, ignorePackage };
+  }
+
+  const gitData = await solveRepositoryPath({ url, branch, subdir });
+  return { dir: gitData.dir, subdir: gitData.subdir, ignorePackage };
 };
 
 export const getPackagePath = async (

--- a/packages/create-node-app-core/tests/paths.test.mts
+++ b/packages/create-node-app-core/tests/paths.test.mts
@@ -43,8 +43,10 @@ test('ignorePackage=true throws when requesting package.json', async () => {
   }
 });
 
-test('invalid template slug triggers fallback error when accessing package.json', async () => {
-  await assert.rejects(() => getPackagePath('non-existent-template', 'package.json'));
+test('invalid template slug falls back to legacy templatesOrExtensions path', async () => {
+  const pkgPath = await getPackagePath('non-existent-template', 'package.json');
+  assert.ok(pkgPath.includes('templatesOrExtensions'));
+  assert.ok(pkgPath.endsWith('package.json'));
 });
 
 test('github style URL with branch and subdir parses without throwing', async () => {
@@ -113,19 +115,13 @@ test('github style URL with tree but empty branch segment handled gracefully', a
   assert.ok(dir.includes('.cna'));
 });
 
-test('github clone path executes try/catch when CNA_SKIP_GIT not set', async () => {
+test('github clone path rejects when repository does not exist and CNA_SKIP_GIT not set', async () => {
   delete process.env.CNA_SKIP_GIT;
   const url = 'https://github.com/definitely-not-a-real-org-xyz123/definitely-not-a-real-repo-xyz123';
-  // Silence expected git clone errors/noise
-  const originalError = console.error;
-  const originalWarn = console.warn;
-  console.error = () => {};
-  console.warn = () => {};
-  const dir = await getTemplateDirPath(url);
-  console.error = originalError;
-  console.warn = originalWarn;
-  // Even on failure we should still get a cache directory path
-  assert.ok(dir.includes('.cna'));
+  await assert.rejects(
+    () => getTemplateDirPath(url),
+    /Could not fetch template/,
+  );
 });
 
 test('file:// subdir without template directory triggers fs.stat error branch and returns subdir path', async () => {


### PR DESCRIPTION
## Summary
- Add `SECURITY.md`, `FUNDING.yml`, and troubleshooting/migration guides (#126, #129, #127, #128)
- Surface clear errors when remote template URLs return 404/403 instead of failing silently (#123)
- Fix `--set` parsing so values containing spaces are preserved (#124)

## Test plan
- [x] `@create-node-app/core` unit tests pass (15/15)
- [x] `parseSetOverrides` unit tests pass (4/4)
- [ ] CI workflows green

Closes #123, #124, #126, #127, #128, #129

Made with [Cursor](https://cursor.com)