### PR TITLE
fix: show clear error when remote template URL returns 404

### DIFF
--- a/packages/create-node-app-core/git.ts
+++ b/packages/create-node-app-core/git.ts
@@ -1,6 +1,7 @@
 import os from "os";
 import path from "path";
 import fs from "fs";
+import pc from "picocolors";
 import debug from "debug";
 import { simpleGit, type SimpleGit, type CloneOptions } from "simple-git";
 import * as fse from "fs-extra"; // Import fs-extra for advanced file operations
@@ -117,7 +118,74 @@ export const downloadRepository = async ({
       // Mark the targetId as completed
       completedTargetIds.set(id, true);
     } catch (error) {
-      console.error("Error during repository download:", error);
+      const errMsg = String(error);
+
+      // Provide user-friendly error messages for common failure scenarios
+      if (
+        errMsg.includes("not found") ||
+        errMsg.includes("404") ||
+        errMsg.includes("Repository not found") ||
+        errMsg.includes("does not exist")
+      ) {
+        console.error(
+          pc.red(`\nError: Could not fetch template from '${gitUrl}'.`),
+        );
+        console.error(
+          pc.red(
+            `  \u2192 The repository was not found. Please verify the URL is correct.`,
+          ),
+        );
+        console.error(
+          pc.gray(
+            `  \u2192 Run 'npx create-awesome-node-app --list-templates' to see available templates.`,
+          ),
+        );
+      } else if (
+        errMsg.includes("403") ||
+        errMsg.includes("forbidden") ||
+        errMsg.includes("Permission denied")
+      ) {
+        console.error(
+          pc.red(`\nError: Access denied when fetching template from '${gitUrl}'.`),
+        );
+        console.error(
+          pc.red(
+            `  \u2192 The repository exists but may be private.`,
+          ),
+        );
+      } else if (
+        errMsg.includes("ECONNREFUSED") ||
+        errMsg.includes("ENOTFOUND") ||
+        errMsg.includes("ETIMEDOUT") ||
+        errMsg.includes("network")
+      ) {
+        console.error(
+          pc.red(`\nError: Network error when fetching template from '${gitUrl}'.`),
+        );
+        console.error(
+          pc.red(
+            `  \u2192 Could not reach the repository. Please check your internet connection.`,
+          ),
+        );
+      } else {
+        console.error(
+          pc.red("Error during repository download:"),
+          error,
+        );
+      }
+
+      // Clean up partially created target directory on failure
+      if (fs.existsSync(absoluteTarget)) {
+        try {
+          fse.removeSync(absoluteTarget);
+          log("Cleaned up partially created directory: %s", absoluteTarget);
+        } catch (cleanupErr) {
+          log("Failed to clean up directory: %s", cleanupErr);
+        }
+      }
+
+      // Re-throw so callers know the operation failed
+      throw error;
     } finally {
       // Remove the promise from the map when the operation is complete
       gitOperationMap.delete(id);

--- a/packages/create-node-app-core/git.ts
+++ b/packages/create-node-app-core/git.ts
@@ -50,6 +50,7 @@ export const downloadRepository = async ({
   const absoluteTarget = path.isAbsolute(target)
     ? target
     : path.resolve(target);
+  const targetExistedBefore = fs.existsSync(absoluteTarget);
 
   const isGithub = /^[^/]+\/[^/]+$/.test(url);
   const gitUrl = isGithub ? `https://github.com/${url}` : url;
@@ -175,7 +176,7 @@ export const downloadRepository = async ({
       }
 
       // Clean up partially created target directory on failure
-      if (fs.existsSync(absoluteTarget)) {
+      if (!targetExistedBefore && fs.existsSync(absoluteTarget)) {
         try {
           fse.removeSync(absoluteTarget);
           log("Cleaned up partially created directory: %s", absoluteTarget);

--- a/packages/create-node-app-core/paths.ts
+++ b/packages/create-node-app-core/paths.ts
@@ -1,7 +1,10 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
+import debug from "debug";
 import { downloadRepository } from "./git.js";
+
+const log = debug("cna:paths");
 
 /**
  * Parse a template / extension URL (supports GitHub style and file:// URLs).
@@ -88,8 +91,10 @@ const solveRepositoryPath = async ({
       target,
       targetId,
     });
-  } catch {
-    // Ignore git error
+  } catch (err) {
+    // downloadRepository already printed a user-friendly error message.
+    // Re-throw so the caller can decide how to handle the fallback.
+    throw err;
   }
 
   return { dir: target, subdir };
@@ -119,6 +124,7 @@ const solveTemplateOrExtensionPath = async (
     return { dir: gitData.dir, subdir: gitData.subdir, ignorePackage };
   } catch {
     // Fallback to an internal templatesOrExtensions directory (legacy behaviour)
+    log("Falling back to legacy template path for: %s", templateOrExtension);
     return {
       dir: path.resolve(
         __dirname,


### PR DESCRIPTION
## Summary

Fixes #123 — When a non-existent remote template URL is provided, the scaffolding process now shows a clear, actionable error message and cleans up the partially created directory.

## Problem

Previously, when running:
```bash
npx create-awesome-node-app my-app --template https://github.com/nonexistent/repo
```

The process would fail with a generic error or hang silently, leaving behind a partially created directory with no guidance for the user.

## Solution

### `packages/create-node-app-core/git.ts`
- **Categorized error handling:** Detects 404/not-found, 403/forbidden, and network errors (ECONNREFUSED, ENOTFOUND, ETIMEDOUT), mapping each to a specific user-friendly message with recovery suggestions
- **Directory cleanup:** On failure, removes the partially created target directory so users aren't left with broken files
- **Re-throws errors:** Instead of silently catching, errors are re-thrown so callers are aware of the failure
- **Visual feedback:** Uses `picocolors` (already a dependency) for red error text

Example output for a 404:
```
Error: Could not fetch template from 'https://github.com/nonexistent/repo'.
  → The repository was not found. Please verify the URL is correct.
  → Run 'npx create-awesome-node-app --list-templates' to see available templates.
```

### `packages/create-node-app-core/paths.ts`
- `solveRepositoryPath` now re-throws errors from `downloadRepository` instead of silently swallowing them with `// Ignore git error`
- `solveTemplateOrExtensionPath` catches at the higher level and falls back to legacy template path with debug logging
- Added `debug` logging for the fallback path

## Testing

- Error messages display correctly for 404, 403, and network errors
- Partial directory cleanup works on failure
- Legacy fallback path still works (caught at `solveTemplateOrExtensionPath` level)
- `CNA_SKIP_GIT=1` test helper still works (returns early before any network calls)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change is backward compatible — callers that catch errors will still work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer, colorized console error messages when repository downloads fail, with tailored guidance for missing repositories, access issues, and network problems.

- **Bug Fixes**
  - Improved cleanup after failed repository setup by removing partially created target folders when applicable.
  - Made legacy template path fallback more transparent by logging when fallback behavior is used.
  - Stopped silently ignoring git clone failures during repository path resolution, ensuring errors are surfaced to the caller.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->