### PR TITLE
Dependabot auto-merge, grouped updates, and Bun CI scaffold

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -13,6 +13,7 @@
   "noConfigSearch": true,
   "words": [
     "megalinter",
+    "nextjs",
     "oxsecurity",
     "alstr",
     "ludeeus",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,15 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: npm
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+    groups:
+      development-dependencies:
+        dependency-type: development
+      production-dependencies:
+        dependency-type: production
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   dependabot:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Dependabot metadata

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,14 +35,20 @@ jobs:
       - name: Run unit tests
         run: npm test
 
-  # Cross-platform scaffolding tests (Windows & macOS)
+  # Cross-platform scaffolding tests (Node on Windows/macOS, Bun on Ubuntu)
   cross-platform-scaffold:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            runtime: bun
+          - os: windows-latest
+            runtime: node
+          - os: macos-latest
+            runtime: node
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -53,30 +59,41 @@ jobs:
           node-version-file: .node-version
           cache: npm
 
+      - name: Setup Bun
+        if: matrix.runtime == 'bun'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
       - name: Install dependencies
         run: npm ci
 
       - name: Build
         run: npm run build
 
-      - name: Test scaffold on ${{ matrix.os }}
+      - name: Test scaffold on ${{ matrix.os }} (${{ matrix.runtime }})
         shell: bash
         run: |
           TEMP_DIR="${RUNNER_TEMP}/scaffold-test"
           mkdir -p "$TEMP_DIR"
           cd "$TEMP_DIR"
 
-          # Test scaffold command using locally built CLI
-          echo "Testing scaffold on ${{ matrix.os }}..."
-          CI=true node "$GITHUB_WORKSPACE/packages/create-awesome-node-app/index.js" test-project \
-            -t "nextjs-starter" \
-            --no-install
-
-          # Verify the project was created
-          if [ -d "test-project" ]; then
-            echo "✅ Project created successfully on ${{ matrix.os }}"
+          CLI="$GITHUB_WORKSPACE/packages/create-awesome-node-app/index.js"
+          echo "Testing scaffold on ${{ matrix.os }} with ${{ matrix.runtime }}..."
+          if [ "${{ matrix.runtime }}" = "bun" ]; then
+            CI=true bun run "$CLI" test-project \
+              -t "nextjs-starter" \
+              --no-install
           else
-            echo "❌ Project creation failed on ${{ matrix.os }}"
+            CI=true node "$CLI" test-project \
+              -t "nextjs-starter" \
+              --no-install
+          fi
+
+          if [ -d "test-project" ]; then
+            echo "✅ Project created successfully on ${{ matrix.os }} (${{ matrix.runtime }})"
+          else
+            echo "❌ Project creation failed on ${{ matrix.os }} (${{ matrix.runtime }})"
             exit 1
           fi
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .node-version
           cache: npm
@@ -51,10 +51,10 @@ jobs:
             runtime: node
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .node-version
           cache: npm
@@ -106,9 +106,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .node-version
           cache: npm
@@ -120,7 +120,7 @@ jobs:
           SKIP_SMOKE: 1
         run: npm run test:coverage
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-lcov
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -52,6 +54,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -107,6 +111,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:


### PR DESCRIPTION
## Summary
- Group npm and GitHub Actions Dependabot updates in `dependabot.yml`
- Add `dependabot-auto-merge.yml` to squash-merge patch Dependabot PRs after CI passes
- Extend cross-platform scaffold matrix with Bun on Ubuntu (Node remains on Windows/macOS)

## Dependabot backlog triage
Open Dependabot PRs (#112, #116–#120) are minor/major bumps (TypeScript 6, Next 16, axios minor, etc.) — not eligible for patch auto-merge. They need manual review or dedicated upgrade PRs.

## Test plan
- [x] CI runs unit tests, coverage, and cross-platform scaffold matrix
- [ ] Verify Bun scaffold job passes on Ubuntu
- [ ] Future patch Dependabot PRs auto-merge when checks are green

Closes #125
Closes #130

Made with [Cursor](https://cursor.com)