### PR TITLE
fix: show clear error when remote template URL returns 404

### DIFF
--- a/packages/create-node-app-core/git.ts
+++ b/packages/create-node-app-core/git.ts
@@ -26,6 +26,14 @@ const formatRepositoryDownloadError = (error: unknown, url: string): string => {
     ].join("\n");
   }
 
+  if (/ECONNREFUSED|ENOTFOUND|ETIMEDOUT|network/i.test(message)) {
+    return [
+      `Error: Could not fetch template from '${url}'.`,
+      "  → Could not reach the repository. Please check your internet connection.",
+      "  → Run 'npx create-awesome-node-app --list-templates' to see available templates.",
+    ].join("\n");
+  }
+
   return [
     `Error: Could not fetch template from '${url}'.`,
     `  → ${message}`,
@@ -75,6 +83,7 @@ export const downloadRepository = async ({
   const absoluteTarget = path.isAbsolute(target)
     ? target
     : path.resolve(target);
+  const targetExistedBefore = fs.existsSync(absoluteTarget);
 
   const isGithub = /^[^/]+\/[^/]+$/.test(url);
   const gitUrl = isGithub ? `https://github.com/${url}` : url;
@@ -143,6 +152,15 @@ export const downloadRepository = async ({
       // Mark the targetId as completed
       completedTargetIds.set(id, true);
     } catch (error) {
+      if (!targetExistedBefore && fs.existsSync(absoluteTarget)) {
+        try {
+          fse.removeSync(absoluteTarget);
+          log("Cleaned up partially created directory: %s", absoluteTarget);
+        } catch (cleanupErr) {
+          log("Failed to clean up directory: %s", cleanupErr);
+        }
+      }
+
       throw new Error(formatRepositoryDownloadError(error, gitUrl));
     } finally {
       // Remove the promise from the map when the operation is complete

--- a/packages/create-node-app-core/paths.ts
+++ b/packages/create-node-app-core/paths.ts
@@ -2,7 +2,10 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
+import debug from "debug";
 import { downloadRepository } from "./git.js";
+
+const log = debug("cna:paths");
 
 const moduleDir =
   typeof __dirname !== "undefined"
@@ -112,6 +115,7 @@ const solveTemplateOrExtensionPath = async (
     parsed = solveValuesFromTemplateOrExtensionUrl(templateOrExtension);
   } catch {
     // Fallback to an internal templatesOrExtensions directory (legacy behavior)
+    log("Falling back to legacy template path for: %s", templateOrExtension);
     return {
       dir: path.resolve(
         moduleDir,


### PR DESCRIPTION
## Summary

Supersedes #132 (community PR from @rudra496) with conflicts resolved on current `main`.

Fixes #123.

- Categorize remote template download failures (404, 403, network) with actionable messages
- Clean up partially created target directories only when this operation created them (CodeRabbit review on #132)
- Log legacy template path fallbacks in `paths.ts`

## Test plan

- [x] `npm test -w packages/create-node-app-core` (15/15 pass)
- [ ] CI green on create-node-app

Closes #132


Made with [Cursor](https://cursor.com)