### PR TITLE
fix: replace chalk with picocolors, unblock stale-version CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8770,13 +8770,14 @@
       }
     },
     "packages/create-awesome-node-app": {
-      "version": "0.8.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
-        "@create-node-app/core": "^0.6.0",
+        "@create-node-app/core": "^0.6.2",
         "axios": "^1.16.0",
         "ci-info": "^4.3.0",
         "commander": "^14.0.3",
+        "picocolors": "^1.1.1",
         "prompts": "^2.4.2",
         "semver": "^7.7.4"
       },
@@ -8784,7 +8785,7 @@
         "create-awesome-node-app": "index.js"
       },
       "devDependencies": {
-        "@create-node-app/core": "^0.6.0",
+        "@create-node-app/core": "^0.6.2",
         "@types/node": "^26.0.1",
         "@types/prompts": "^2.4.9",
         "@types/semver": "^7.5.8",
@@ -9262,6 +9263,22 @@
         "undici-types": "~8.3.0"
       }
     },
+    "packages/create-awesome-node-app/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "packages/create-awesome-node-app/node_modules/axios": {
       "version": "1.13.6",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
@@ -9428,6 +9445,23 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/create-awesome-node-app/node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "packages/create-awesome-node-app/node_modules/espree": {
@@ -9653,7 +9687,7 @@
     },
     "packages/create-node-app-core": {
       "name": "@create-node-app/core",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -10529,7 +10563,7 @@
     },
     "packages/eslint-config-base": {
       "name": "@create-node-app/eslint-config",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "eslint": "^9.35.0",
@@ -10754,7 +10788,7 @@
     },
     "packages/eslint-config-next": {
       "name": "@create-node-app/eslint-config-next",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@create-node-app/eslint-config-ts": "*",
@@ -10979,7 +11013,7 @@
     },
     "packages/eslint-config-react": {
       "name": "@create-node-app/eslint-config-react",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@create-node-app/eslint-config-ts": "*",
@@ -11221,7 +11255,7 @@
     },
     "packages/eslint-config-ts": {
       "name": "@create-node-app/eslint-config-ts",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@create-node-app/eslint-config": "*",
@@ -11463,7 +11497,7 @@
       }
     },
     "packages/tsconfig": {
-      "version": "0.2.0"
+      "version": "0.2.1"
     }
   }
 }

--- a/packages/create-awesome-node-app/package.json
+++ b/packages/create-awesome-node-app/package.json
@@ -78,6 +78,7 @@
     "@create-node-app/core": "^0.6.2",
     "axios": "^1.16.0",
     "ci-info": "^4.3.0",
+    "picocolors": "^1.1.1",
     "commander": "^14.0.3",
     "prompts": "^2.4.2",
     "semver": "^7.7.4"

--- a/packages/create-awesome-node-app/src/index.ts
+++ b/packages/create-awesome-node-app/src/index.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import chalk from "chalk";
+import pc from "picocolors";
 import semver from "semver";
 import {
   createNodeApp,
@@ -27,7 +27,7 @@ const main = async () => {
   program
     .version(packageJson.version)
     .arguments("[project-directory]")
-    .usage(`${chalk.green("[project-directory]")} [options]`)
+    .usage(`${pc.green("[project-directory]")} [options]`)
     .option("-v, --verbose", "print additional logs")
     .option("-i, --info", "print environment debug info")
     .option(
@@ -76,13 +76,12 @@ const main = async () => {
   const latestVersion = await checkForLatestVersion("create-awesome-node-app");
   if (latestVersion && semver.lt(packageJson.version, latestVersion)) {
     console.log();
-    console.error(
-      chalk.yellow(
+    console.warn(
+      pc.yellow(
         `You are running \`create-awesome-node-app\` ${packageJson.version}, which is behind the latest release (${latestVersion}).\n\n` +
-          "We recommend always using the latest version of create-awesome-node-app if possible.",
+          "We recommend always using the latest version of create-awesome-node-app if possible.\n",
       ),
     );
-    return;
   }
 
   // Handle list templates flag

--- a/packages/create-awesome-node-app/src/list.ts
+++ b/packages/create-awesome-node-app/src/list.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import pc from "picocolors";
 import {
   getTemplateCategories,
   getTemplatesForCategory,
@@ -14,7 +14,7 @@ import {
 export const listTemplates = async () => {
   const categories = await getTemplateCategories();
 
-  console.log(chalk.bold.blue("\nAvailable Templates:"));
+  console.log(pc.bold(pc.blue("\nAvailable Templates:")));
 
   for (const categorySlug of categories) {
     const categoryData = await getCategoryData(categorySlug);
@@ -22,7 +22,7 @@ export const listTemplates = async () => {
 
     // Display category name if available, otherwise use the slug
     const categoryName = categoryData?.name || categorySlug;
-    console.log(chalk.bold.green(`\n${categoryName}:`));
+    console.log(pc.bold(pc.green(`\n${categoryName}:`)));
 
     // Display category description if available
     if (categoryData?.description) {
@@ -30,9 +30,7 @@ export const listTemplates = async () => {
     }
 
     templates.forEach((template: TemplateData) => {
-      console.log(
-        `  ${chalk.yellow(template.name)} (${chalk.cyan(template.slug)})`,
-      );
+      console.log(`  ${pc.yellow(template.name)} (${pc.cyan(template.slug)})`);
       console.log(`    ${template.description}`);
       if (template.labels && template.labels.length > 0) {
         console.log(`    Keywords: ${template.labels.join(", ")}`);
@@ -62,11 +60,11 @@ export const listAddons = async ({
   const extensionsGroupedByCategory =
     await getExtensionsGroupedByCategory(types);
 
-  console.log(chalk.bold.blue("\nAvailable Addons:"));
+  console.log(pc.bold(pc.blue("\nAvailable Addons:")));
 
   if (templateSlug) {
     console.log(
-      chalk.bold.green(`\nCompatible with template: ${templateSlug}`),
+      pc.bold(pc.green(`\nCompatible with template: ${templateSlug}`)),
     );
   }
 
@@ -77,7 +75,7 @@ export const listAddons = async ({
 
     // Display category name if available, otherwise use the slug
     const categoryName = categoryData?.name || categorySlug;
-    console.log(chalk.bold.green(`\n${categoryName}:`));
+    console.log(pc.bold(pc.green(`\n${categoryName}:`)));
 
     // Display category description if available
     if (categoryData?.description) {
@@ -86,7 +84,7 @@ export const listAddons = async ({
 
     (extensions as ExtensionData[]).forEach((extension: ExtensionData) => {
       console.log(
-        `  ${chalk.yellow(extension.name)} (${chalk.cyan(extension.slug)})`,
+        `  ${pc.yellow(extension.name)} (${pc.cyan(extension.slug)})`,
       );
       console.log(`    ${extension.description}`);
       if (extension.labels && extension.labels.length > 0) {


### PR DESCRIPTION
## Summary

Fixes two production bugs in the CLI packaging and adds version-gate flexibility:

### 1. Missing runtime dependency
`create-awesome-node-app` imported `chalk` but never declared it as a dependency. It was resolved transitively via chalk v4 (CJS-compatible). Adding chalk v5 would break the CJS bundle because chalk v5 is ESM-only and the CLI entry point wraps `dist/index.cjs`.

**Fix:** Replace `chalk` with `picocolors` — 1/8 the size, CJS + ESM compatible, and already a transitive dep via `@create-node-app/core`.

### 2. Version gate blocks all commands
`checkForLatestVersion` was called before command dispatch and used `return` (exit main) when a newer npm version was found. This blocked:
- `--list-templates` / `--list-addons` (no execution needed)
- CI/CD pinning to a specific version
- Reproducible scaffolding with specific releases

**Fix:** Warn but continue execution.

### 3. picocolors API fix
picocolors does not support chaining (`pc.bold.green`). Changed to nested calls (`pc.bold(pc.green(...))`).

## Validation
- `npm run build` ✔
- `npm run lint` ✔
- `npm run type-check` ✔
- `npm run test:all` — 29/29 tests pass (including smoke test with real scaffolding)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the CLI’s colored output for template and addon listings, improving readability.
* **Bug Fixes**
  * Adjusted the “out of date” warning to display in a less severe warning format.
  * Improved line wrapping and formatting in the update notice for clearer messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->