### PR TITLE
fix: fail on non-empty target directory unless --force

### DIFF
--- a/packages/create-awesome-node-app/README.md
+++ b/packages/create-awesome-node-app/README.md
@@ -46,7 +46,7 @@ npx create-awesome-node-app my-app \
 ```
 
 | If you want...                | Start here                                        |
-| ----------------------------- | ------------------------------------------------- |
+|-------------------------------|---------------------------------------------------|
 | A guided local setup          | `npm create awesome-node-app@latest my-app`       |
 | A repeatable CI/platform flow | `--no-interactive` with explicit flags            |
 | Your company starter          | `--template <github-url>` or `--template file://` |
@@ -56,11 +56,11 @@ npx create-awesome-node-app my-app \
 
 ## ✨ Why CNA?
 
-| Capability                       | Value                                                                                                 |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| 🧩 **Composable by design**      | Start with a template, then layer only the addons your project actually needs.                        |
+| Capability                        | Value                                                                                                 |
+|-----------------------------------|-------------------------------------------------------------------------------------------------------|
+| 🧩 **Composable by design**       | Start with a template, then layer only the addons your project actually needs.                        |
 | 🛡️ **Production-ready defaults** | TypeScript, linting, scripts, testing paths, and practical DX defaults out of the box.                |
-| 🤖 **AI-ready from day one**     | Supported templates generate `AGENTS.md` so coding agents understand the project context.             |
+| 🤖 **AI-ready from day one**      | Supported templates generate `AGENTS.md` so coding agents understand the project context.             |
 | 🏗️ **CI and platform friendly**  | Use `--no-interactive`, `--set`, `--template <url>`, and `--extend <url>` for repeatable scaffolding. |
 
 ---
@@ -80,7 +80,7 @@ You can mix catalog templates and addons with your own GitHub or `file://` sourc
 ### 🧱 Template Families
 
 | Category      | Example templates                                           |
-| ------------- | ----------------------------------------------------------- |
+|---------------|-------------------------------------------------------------|
 | Frontend      | `react-vite-boilerplate`, `astro-starter`                   |
 | Backend       | `nestjs-boilerplate`, `hono-starter`                        |
 | Full Stack    | `nextjs-starter`, `nextjs-saas-ai-starter`, `remix-starter` |
@@ -91,7 +91,7 @@ You can mix catalog templates and addons with your own GitHub or `file://` sourc
 ### 🧰 Addon Families
 
 | Category                  | Examples                                                                  |
-| ------------------------- | ------------------------------------------------------------------------- |
+|---------------------------|---------------------------------------------------------------------------|
 | UI                        | `tailwind-css`, `material-ui`, `shadcn-ui`, `nextjs-shadcn`               |
 | State and data            | `zustand`, `jotai`, `tanstack-react-query`, `apollo-client`               |
 | Backend and DB            | `drizzle-orm-postgresql`, `drizzle-orm-sqlite`, `mongoose-orm-mongodb`    |
@@ -215,7 +215,7 @@ Full catalog:
 Supported templates can generate an `AGENTS.md` file so coding assistants understand project context before editing:
 
 | Context                | Why it matters                                              |
-| ---------------------- | ----------------------------------------------------------- |
+|------------------------|-------------------------------------------------------------|
 | Project purpose        | Agents understand what the app is for before changing code. |
 | Directory layout       | Suggestions align with the real structure.                  |
 | Scripts and validation | Agents know how to lint, test, build, and verify changes.   |
@@ -230,7 +230,7 @@ Learn more: **[AGENTS.md guide](https://create-awesome-node-app.vercel.app/docs/
 Run the CLI without flags and CNA guides you through:
 
 | Step              | What you choose                                                            |
-| ----------------- | -------------------------------------------------------------------------- |
+|-------------------|----------------------------------------------------------------------------|
 | Project name      | Confirm or set the target directory                                        |
 | Package manager   | npm, yarn, pnpm, or Bun                                                    |
 | Category          | Frontend, Backend, Full Stack, Monorepo, Web Extension, UAT, or custom URL |
@@ -261,7 +261,7 @@ Usage: create-awesome-node-app [project-directory] [options]
 ```
 
 | Flag                         | Description                                           |
-| ---------------------------- | ----------------------------------------------------- |
+|------------------------------|-------------------------------------------------------|
 | `--interactive`              | Force interactive wizard (default outside CI)         |
 | `--no-interactive`           | Disable wizard and use flags only                     |
 | `-t, --template <slug\|url>` | Template slug from catalog or remote/local URL        |

--- a/packages/create-awesome-node-app/README.md
+++ b/packages/create-awesome-node-app/README.md
@@ -269,6 +269,7 @@ Usage: create-awesome-node-app [project-directory] [options]
 | `--extend [urls...]`         | Extra extension URLs layered on top                   |
 | `--set <key=value...>`       | Set custom template options; quote values with spaces |
 | `--no-install`               | Generate files without installing dependencies        |
+| `-f, --force`                | Allow scaffolding into a non-empty target directory   |
 | `--use-yarn`                 | Use yarn instead of npm, pnpm, or Bun                 |
 | `--use-pnpm`                 | Use pnpm instead of npm, yarn, or Bun                 |
 | `--use-bun`                  | Use Bun instead of npm, yarn, or pnpm                 |

--- a/packages/create-awesome-node-app/src/index.ts
+++ b/packages/create-awesome-node-app/src/index.ts
@@ -5,6 +5,7 @@ import {
   createNodeApp,
   checkForLatestVersion,
   checkNodeVersion,
+  NON_EMPTY_DIR_ERROR_CODE,
   type TemplateOrExtension,
 } from "@create-node-app/core";
 import { getCnaOptions } from "./options.js";
@@ -49,6 +50,7 @@ const main = async () => {
     .option("--use-yarn", "use yarn instead of npm or pnpm or bun")
     .option("--use-pnpm", "use pnpm instead of yarn, npm, or bun")
     .option("--use-bun", "use bun instead of npm, yarn, or pnpm")
+    .option("-f, --force", "allow scaffolding into a non-empty directory")
     .option(
       "--interactive",
       "force interactive mode (default outside CI unless --no-interactive)",
@@ -134,6 +136,17 @@ const main = async () => {
 
 main().catch((err) => {
   const verbose = Boolean(program.opts()?.verbose);
+
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: string }).code === NON_EMPTY_DIR_ERROR_CODE
+  ) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(pc.red(message));
+    process.exit(1);
+  }
 
   if (err instanceof Error) {
     console.error(pc.red(err.message));

--- a/packages/create-node-app-core/config.ts
+++ b/packages/create-node-app-core/config.ts
@@ -14,6 +14,33 @@ export type CnaConfig = {
   customOptions?: CnaCustomOption[];
 };
 
+export const NON_EMPTY_DIR_ERROR_CODE = "CNA_NON_EMPTY_TARGET_DIR";
+
+export class NonEmptyTargetDirectoryError extends Error {
+  readonly code = NON_EMPTY_DIR_ERROR_CODE;
+
+  constructor(readonly targetPath: string) {
+    super(
+      `Target directory is not empty: ${targetPath}. Use --force to continue.`,
+    );
+    this.name = "NonEmptyTargetDirectoryError";
+  }
+}
+
+export const assertDirectoryIsEmpty = (dirPath: string) => {
+  if (!fs.existsSync(dirPath)) {
+    return;
+  }
+
+  const entries = fs
+    .readdirSync(dirPath)
+    .filter((entry) => entry !== ".DS_Store" && entry !== "Thumbs.db");
+
+  if (entries.length > 0) {
+    throw new NonEmptyTargetDirectoryError(dirPath);
+  }
+};
+
 /**
  * Load cna.config.json from the base directory of a template.
  *

--- a/packages/create-node-app-core/index.ts
+++ b/packages/create-node-app-core/index.ts
@@ -14,6 +14,11 @@ export {
 export { downloadRepository } from "./git.js";
 export { loadTemplateCnaConfig } from "./config.js";
 export type { CnaConfig, CnaCustomOption } from "./config.js";
+export {
+  assertDirectoryIsEmpty,
+  NonEmptyTargetDirectoryError,
+  NON_EMPTY_DIR_ERROR_CODE,
+} from "./config.js";
 
 export const checkNodeVersion = (
   requiredVersion: string,
@@ -81,6 +86,7 @@ export type CnaOptions = {
   projectName: string;
   info?: boolean;
   verbose?: boolean;
+  force?: boolean;
   packageManager?: string;
   install?: boolean;
   template?: string;

--- a/packages/create-node-app-core/installer.ts
+++ b/packages/create-node-app-core/installer.ts
@@ -22,6 +22,7 @@ import { loadPackages } from "./package.js";
 import type { TemplateOrExtension } from "./loaders.js";
 import { loadFiles } from "./loaders.js";
 import { resolveExecutable } from "./executable.js";
+import { assertDirectoryIsEmpty } from "./config.js";
 
 const install = async (
   root: string,
@@ -399,6 +400,7 @@ const run = async ({
 export type CreateAppOptions = {
   name: string;
   verbose?: boolean;
+  force?: boolean;
   packageManager?: string;
   templatesOrExtensions?: TemplateOrExtension[];
   installDependencies?: boolean;
@@ -410,6 +412,7 @@ export type CreateAppOptions = {
 export const createApp = async ({
   name,
   verbose = false,
+  force = false,
   templatesOrExtensions = [],
   installDependencies = true,
   ignorePackage = false,
@@ -421,6 +424,10 @@ export const createApp = async ({
   fs.mkdirSync(name, {
     recursive: true,
   });
+
+  if (!force) {
+    assertDirectoryIsEmpty(root);
+  }
 
   console.log(`Creating a new Node app in ${pc.green(root)}.`);
   console.log();

--- a/packages/create-node-app-core/tests/non-empty-dir.test.mts
+++ b/packages/create-node-app-core/tests/non-empty-dir.test.mts
@@ -25,6 +25,18 @@ test("assertDirectoryIsEmpty allows empty directory", () => {
   rmSync(tmp, { recursive: true, force: true });
 });
 
+test("assertDirectoryIsEmpty ignores noise files", () => {
+  const tmp = mkdtempSync(path.join(tmpdir(), "cna-noise-"));
+  const noiseDir = path.join(tmp, "noise");
+  mkdirSync(noiseDir, { recursive: true });
+  writeFileSync(path.join(noiseDir, ".DS_Store"), "");
+  writeFileSync(path.join(noiseDir, "Thumbs.db"), "");
+
+  assert.doesNotThrow(() => assertDirectoryIsEmpty(noiseDir));
+
+  rmSync(tmp, { recursive: true, force: true });
+});
+
 test("assertDirectoryIsEmpty throws on non-empty directory", () => {
   const tmp = mkdtempSync(path.join(tmpdir(), "cna-non-empty-"));
   const nonEmptyDir = path.join(tmp, "target");

--- a/packages/create-node-app-core/tests/non-empty-dir.test.mts
+++ b/packages/create-node-app-core/tests/non-empty-dir.test.mts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  assertDirectoryIsEmpty,
+  NON_EMPTY_DIR_ERROR_CODE,
+  NonEmptyTargetDirectoryError,
+} from "../config.js";
+
+test("assertDirectoryIsEmpty allows missing directory", () => {
+  const dir = path.join(tmpdir(), "cna-non-empty-missing-do-not-create");
+  assert.doesNotThrow(() => assertDirectoryIsEmpty(dir));
+});
+
+test("assertDirectoryIsEmpty allows empty directory", () => {
+  const tmp = mkdtempSync(path.join(tmpdir(), "cna-empty-"));
+  const emptyDir = path.join(tmp, "empty");
+  mkdirSync(emptyDir, { recursive: true });
+
+  assert.doesNotThrow(() => assertDirectoryIsEmpty(emptyDir));
+
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+test("assertDirectoryIsEmpty throws on non-empty directory", () => {
+  const tmp = mkdtempSync(path.join(tmpdir(), "cna-non-empty-"));
+  const nonEmptyDir = path.join(tmp, "target");
+  mkdirSync(nonEmptyDir, { recursive: true });
+  writeFileSync(path.join(nonEmptyDir, "existing.txt"), "keep");
+
+  assert.throws(
+    () => assertDirectoryIsEmpty(nonEmptyDir),
+    (error: unknown) => {
+      assert.ok(error instanceof NonEmptyTargetDirectoryError);
+      assert.equal(error.code, NON_EMPTY_DIR_ERROR_CODE);
+      assert.match(error.message, /Use --force to continue\./);
+      return true;
+    },
+  );
+
+  rmSync(tmp, { recursive: true, force: true });
+});


### PR DESCRIPTION
## What
- add a preflight guard that rejects scaffolding into non-empty directories by default
- introduce a dedicated non-empty-directory error type with stable error code for clean CLI handling
- add --force flag to explicitly allow scaffolding into non-empty directories
- document --force in the CLI reference
- add tests covering missing/empty/non-empty target directory behavior

## Why
In --no-interactive runs the CLI previously scaffolded into non-empty folders without warning, which is risky in CI/automation and can silently mix files.

Closes #159

## Validation
- npm run test:all -- packages/create-node-app-core/tests/non-empty-dir.test.mts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--force` flag to allow scaffolding into a non-empty directory.
  * Improved empty-directory checks so setup continues smoothly when the target is missing or only contains common OS files.

* **Bug Fixes**
  * Clearer error handling now shows a friendlier message when the target directory already has files.
  * Updated CLI guidance to explain how to continue when the destination is not empty.

* **Documentation**
  * Refreshed command-line reference tables and added the new `--force` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->