### PR TITLE
fix: show concise validation errors unless --verbose

### DIFF
--- a/packages/create-awesome-node-app/src/index.ts
+++ b/packages/create-awesome-node-app/src/index.ts
@@ -133,6 +133,15 @@ const main = async () => {
 };
 
 main().catch((err) => {
-  console.error(err);
+  const verbose = Boolean(program.opts()?.verbose);
+
+  if (err instanceof Error) {
+    console.error(pc.red(err.message));
+    if (verbose && err.stack) {
+      console.error(err.stack);
+    }
+  } else {
+    console.error(err);
+  }
   process.exit(1);
 });

--- a/packages/create-awesome-node-app/tests/error-output.test.mts
+++ b/packages/create-awesome-node-app/tests/error-output.test.mts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import pc from "picocolors";
+
+test("expected errors print only message when not verbose", () => {
+  const error = new Error("Invalid extension slug: 'x'.");
+
+  const messages: string[] = [];
+  const originalError = console.error;
+  console.error = (...args: unknown[]) => {
+    messages.push(String(args[0]));
+  };
+
+  try {
+    if (error instanceof Error) {
+      console.error(pc.red(error.message));
+    }
+  } finally {
+    console.error = originalError;
+  }
+
+  assert.equal(messages.length, 1);
+  assert.equal(messages[0], pc.red("Invalid extension slug: 'x'."));
+});


### PR DESCRIPTION
## What
- update CLI top-level error handler to print concise user-facing error messages
- keep stack traces behind --verbose only
- add a focused test covering message-only output for expected errors

## Why
Validation failures (like invalid addon slug) should not look like internal crashes in normal usage.

Closes #160

## Validation
- npm run test:all -- packages/create-awesome-node-app/tests/error-output.test.mts
