### PR TITLE
fix: improve pnpm ERR_PNPM_IGNORED_BUILDS guidance

### DIFF
--- a/packages/create-node-app-core/installer.ts
+++ b/packages/create-node-app-core/installer.ts
@@ -97,8 +97,23 @@ const install = async (
       stdio: "inherit",
     });
   } catch {
-    throw new Error(`${command} ${args.join(" ")}`);
+    throw new Error(buildInstallFailureMessage(command, args, usePnpm));
   }
+};
+
+export const buildInstallFailureMessage = (
+  command: string,
+  args: string[],
+  usePnpm = false,
+) => {
+  if (usePnpm) {
+    return (
+      `${command} ${args.join(" ")}\n` +
+      "If pnpm reports ERR_PNPM_IGNORED_BUILDS, run `pnpm approve-builds` inside the generated project and retry your install command."
+    );
+  }
+
+  return `${command} ${args.join(" ")}`;
 };
 
 export type RunOptions = {

--- a/packages/create-node-app-core/tests/pnpm-error-message.test.mts
+++ b/packages/create-node-app-core/tests/pnpm-error-message.test.mts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { buildInstallFailureMessage } from "../installer.js";
+
+test("pnpm failure message includes ignored builds guidance", () => {
+  const message = buildInstallFailureMessage(
+    "pnpm",
+    ["install", "--ignore-workspace"],
+    true,
+  );
+
+  assert.match(message, /pnpm install --ignore-workspace/);
+  assert.match(message, /ERR_PNPM_IGNORED_BUILDS/);
+  assert.match(message, /pnpm approve-builds/);
+});
+
+test("non-pnpm failure message remains unchanged", () => {
+  const message = buildInstallFailureMessage("npm", ["install"], false);
+  assert.equal(message, "npm install");
+});


### PR DESCRIPTION
## What
- add pnpm-specific install failure guidance in core installer errors
- include explicit next step for pnpm build-script approval (run: pnpm approve-builds)
- add tests for pnpm and non-pnpm failure message paths

## Why
With pnpm 11, installs can fail on ERR_PNPM_IGNORED_BUILDS. CNA should return actionable guidance instead of a raw install command only.

Closes #158

## Validation
- npm run test:all -- packages/create-node-app-core/tests/pnpm-error-message.test.mts
