### PR TITLE
fix(ci): use npm trusted publishing (OIDC) with protected npm-publish environment

### DIFF
--- a/.changeset/trusted-publishing-oidc.md
+++ b/.changeset/trusted-publishing-oidc.md
@@ -1,0 +1,10 @@
+---
+"@create-node-app/core": patch
+"@create-node-app/eslint-config": patch
+"@create-node-app/eslint-config-next": patch
+"@create-node-app/eslint-config-react": patch
+"@create-node-app/eslint-config-ts": patch
+"create-awesome-node-app": patch
+---
+
+fix(ci): switch to npm trusted publishing via OIDC with protected npm-publish environment

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,21 +5,46 @@ on:
     branches:
       - main
 
-permissions:
-  id-token: write
-  contents: write
-  packages: write
-  pull-requests: write
-  issues: read
-
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  release:
-    name: Release
+  release-pr:
+    name: Create Release Pull Request
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+    outputs:
+      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Create Release Pull Request
+        id: changesets
+        uses: changesets/action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish to npm
+    needs: release-pr
+    if: needs.release-pr.outputs.hasChangesets == 'false'
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      id-token: write # Required for OIDC trusted publishing
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -30,18 +55,7 @@ jobs:
           registry-url: "https://registry.npmjs.org/"
           scope: "@create-node-app"
           cache: npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Install dependencies
         run: npm ci
-      - name: Create Release Pull Request
-        id: changesets
-        uses: changesets/action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish
-        if: steps.changesets.outputs.hasChangesets == 'false'
+      - name: Publish packages
         run: npm run publish-packages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# What's this PR do?

This PR switches the GitHub Actions release workflow from legacy token-based npm authentication to **npm Trusted Publishing via OIDC**, solving the MFA/OTP failure that has been blocking automated publishes. It also gates the actual `npm publish` step behind a protected GitHub environment so a maintainer approval is required before anything reaches the registry.

## Problem
The current release workflow uses a long-lived `NPM_TOKEN` secret. With MFA enabled on the npm account, classic tokens trigger an OTP prompt during `npm publish`, which fails in GitHub Actions. Recent runs were canceled during the publish step because of this.

## Solution
Switch to **npm Trusted Publishing** via OIDC and protect the publish step with a GitHub Actions environment. This is the recommended approach for MFA-enabled accounts and eliminates the need for any long-lived npm token in GitHub secrets.

Docs: https://docs.npmjs.com/trusted-publishers

## What changed
- Refactored the workflow into two jobs:
  - `release-pr`: creates/updates the changeset release PR (runs automatically on every push to `main`).
  - `publish`: publishes to npm only after the release PR has been merged (when `hasChangesets == 'false'`).
- Added `environment: npm-publish` to the `publish` job, so publish runs require manual approval from a configured maintainer.
- Removed `NPM_TOKEN` entirely; `id-token: write` enables the npm CLI to authenticate via OIDC.
- Scoped permissions per job to the least privilege necessary.

## Required manual setup before merge

### 1. Create the GitHub environment
- Go to GitHub repo → **Settings** → **Environments** → **New environment**
- Name: `npm-publish`
- Add protection rules:
  - **Required reviewers:** add yourself (or other maintainers who can approve releases)
  - (Optional) **Wait timer**, **Deployment branches** as needed

### 2. Add Trusted Publishers on npmjs.com
For each package published from this monorepo, go to **Package** → **Settings** → **Trusted publishing** and add a GitHub Actions publisher with these values (identical for all packages):

| Field | Value |
|-------|-------|
| **Organization or user** | `Create-Node-App` |
| **Repository** | `create-node-app` |
| **Workflow filename** | `publish.yml` |
| **Environment name** | `npm-publish` |
| **Allowed actions** | `npm publish` |

Packages to configure:
- `@create-node-app/core`
- `@create-node-app/eslint-config`
- `@create-node-app/eslint-config-next`
- `@create-node-app/eslint-config-react`
- `@create-node-app/eslint-config-ts`
- `create-awesome-node-app`

### 3. Clean up old tokens
After the next successful publish, delete the old `NPM_TOKEN` secret from GitHub → Settings → Secrets and variables → Actions.

### 4. Lock down package publishing (recommended after verification)
On each package's npm settings, select **"Require two-factor authentication and disallow tokens"** so only OIDC trusted publishing can publish.

## Changeset
This PR includes `.changeset/trusted-publishing-oidc.md` with a **patch** bump for every publishable package, so merging it will create a Changesets release PR and let us validate the full trusted-publishing flow.

> Do not merge until the `npm-publish` GitHub environment and the npm Trusted Publishers are configured for all packages above.

## Benefits
- No more OTP prompts or long-lived tokens in CI.
- Manual approval gate before any package is published.
- Automatic [provenance attestations](https://docs.npmjs.com/generating-provenance-statements) on every publish.

## Validation
- Workflow syntax is valid.
- After configuring the environment and trusted publishers, merging this PR should create a release PR, and merging that release PR should trigger the `publish` job and, once approved, complete without tokens.
