### PR TITLE
fix(ci): rely on npm CLI OIDC auto-detection for trusted publishing

### DIFF
--- a/.changeset/npm-oidc-auto-detect.md
+++ b/.changeset/npm-oidc-auto-detect.md
@@ -1,0 +1,12 @@
+---
+"@create-node-app/core": patch
+"@create-node-app/eslint-config": patch
+"@create-node-app/eslint-config-next": patch
+"@create-node-app/eslint-config-react": patch
+"@create-node-app/eslint-config-ts": patch
+"create-awesome-node-app": patch
+---
+
+fix(ci): rely on npm CLI OIDC auto-detection for trusted publishing
+
+Removes the manual OIDC token exchange because npm CLI >= 11.5.1 automatically detects GitHub Actions OIDC and authenticates during `npm publish`. Drops `NODE_AUTH_TOKEN` and `NPM_CONFIG_PROVENANCE` overrides so the CLI can manage both auth and provenance by itself.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,31 +54,11 @@ jobs:
           node-version-file: .node-version
           cache: npm
 
+      - name: Install npm with trusted publishing support
+        run: npm install -g npm@^11.5.1
+
       - name: Install dependencies
         run: npm ci
 
-      - name: Exchange GitHub OIDC token for npm access token
-        id: npm-token
-        run: |
-          set -euo pipefail
-          GH_TOKEN=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=registry.npmjs.org" | jq -r '.value')
-          NPM_RESPONSE=$(curl -sS -X POST -H "Content-Type: application/json" -d "{\"token\":\"$GH_TOKEN\"}" https://registry.npmjs.org/-/npm/v1/security/oidc-token)
-          NPM_TOKEN=$(echo "$NPM_RESPONSE" | jq -r '.token // empty')
-          if [ -z "$NPM_TOKEN" ]; then
-            echo "OIDC token exchange failed" >&2
-            echo "$NPM_RESPONSE" | jq -c . >&2 || echo "$NPM_RESPONSE" >&2
-            exit 1
-          fi
-          echo "::add-mask::$NPM_TOKEN"
-          echo "npm-token=$NPM_TOKEN" >> "$GITHUB_OUTPUT"
-
-      - name: Verify npm identity
-        run: npm whoami --registry=https://registry.npmjs.org/
-        env:
-          NODE_AUTH_TOKEN: ${{ steps.npm-token.outputs.npm-token }}
-
       - name: Publish packages
         run: npm run publish-packages
-        env:
-          NODE_AUTH_TOKEN: ${{ steps.npm-token.outputs.npm-token }}
-          NPM_CONFIG_PROVENANCE: "true"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:fix": "turbo run lint:fix",
     "lint-staged": "lint-staged",
     "prepare": "is-ci || husky",
-    "publish-packages": "turbo run lint && changeset version && turbo run build && changeset publish --provenance",
+    "publish-packages": "turbo run lint && changeset version && turbo run build && changeset publish",
     "storybook": "turbo run storybook",
     "test": "turbo run test",
     "test:all": "tsx --test \"packages/**/tests/**/*.test.mts\"",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to use npm’s built-in trusted publishing flow.
  * Package updates were published as patch releases across affected packages.
  * Simplified publishing configuration to rely on npm for authentication and provenance handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->