### PR TITLE
feat: cache controls and smart refresh (closes #180)

### DIFF
--- a/.changeset/cache-controls-and-smart-refresh.md
+++ b/.changeset/cache-controls-and-smart-refresh.md
@@ -1,0 +1,33 @@
+---
+"create-awesome-node-app": minor
+"@create-node-app/core": minor
+---
+
+Cache controls and smart refresh (sub-issue #180 of epic #179)
+
+**New CLI flags** for the main scaffold command:
+
+- `--offline` — use the local cache only; do not refresh templates from the network
+- `--no-cache` — disable the on-disk catalog cache and force a refresh on every run
+- `--cache-dir <path>` — override the cache root (defaults to `~/.cache/cna`; also honors `CNA_CACHE_DIR`)
+- `--refresh <mode>` — when to refresh the cached template: `always` | `stale` | `manual` (default: `stale`, controlled by `CNA_REFRESH` and `CNA_REFRESH_AFTER_HOURS`)
+
+**New `cna cache` subcommand**:
+
+- `cna cache dir` — print the cache root directory
+- `cna cache list` — list cached templates/extensions (id, url, branch, last fetched, last commit SHA, size)
+- `cna cache clean [id]` — remove one or all entries; pass `--catalog` to also clear the on-disk template catalog cache
+- `cna cache verify [id]` — run `git fsck` on one or all entries, exit non-zero if any entry is corrupt
+
+**Cache layout improvements**:
+
+- Per-entry `.cna-meta.json` sidecar with `lastFetchedAt`, `lastCommitSha`, `lastRefreshReason`, `branch`, and `url`
+- Default refresh mode changed from `always` (unconditional `git pull`) to `stale` (pull only if cache is older than `CNA_REFRESH_AFTER_HOURS`, default 24)
+- Working-copy prep now uses `cp -c` (reflink) / `cp -l` (hardlink) with a recursive copy fallback, so warm scaffolds are O(1) on the working dir
+- The template catalog is now persisted to disk and used as a fallback when the network is unavailable
+
+**Network and dependency hygiene**:
+
+- Dropped the `axios` dependency; the template catalog now uses the global `fetch` with a 10 s timeout and a `User-Agent: create-awesome-node-app/<version>` header
+
+See #179 for the parent epic.

--- a/.cspell.json
+++ b/.cspell.json
@@ -60,7 +60,11 @@
     "Jeremias",
     "readdirp",
     "Ulises",
-    "npmjs"
+    "npmjs",
+    "reflink",
+    "reflinks",
+    "hardlink",
+    "hardlinks"
   ],
   "version": "0.2"
 }

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -84,4 +84,35 @@ When passing custom options that contain spaces, quote the entire `key=value` pa
 npx create-awesome-node-app my-app -t nextjs-starter --set 'projectName=My Awesome Project'
 ```
 
+## Cache location and inspection
+
+By default, CNA caches the template catalog and the template git repos
+under `~/.cache/cna`. The CLI exposes this via:
+
+```bash
+npx create-awesome-node-app cache dir    # print the cache root
+npx create-awesome-node-app cache list   # show entries with id, url, branch, last fetched, sha, size
+npx create-awesome-node-app cache verify # run git fsck on every entry
+npx create-awesome-node-app cache clean  # remove all entries
+npx create-awesome-node-app cache clean <id>   # remove one entry by id
+npx create-awesome-node-app cache clean --catalog   # also clear the catalog cache
+```
+
+If a scaffold "looks weird" and you suspect a stale cache, the first
+diagnostic step is `cache verify`. If any entry fails, `cache clean` and
+re-run.
+
+## Forcing a fresh fetch
+
+```bash
+# Force a re-fetch of templates.json on every run.
+npx create-awesome-node-app my-app -t react-vite-boilerplate --no-cache
+
+# Disable git pull on cache hit (use the local copy as-is).
+npx create-awesome-node-app my-app -t react-vite-boilerplate --offline
+
+# Pin the cache to a project-local directory (useful in CI).
+CNA_CACHE_DIR="$PWD/.cna-cache" npx create-awesome-node-app my-app -t react-vite-boilerplate
+```
+
 See also: [MIGRATION.md](./MIGRATION.md) for keeping scaffolded projects up to date.

--- a/packages/create-awesome-node-app/README.md
+++ b/packages/create-awesome-node-app/README.md
@@ -46,7 +46,7 @@ npx create-awesome-node-app my-app \
 ```
 
 | If you want...                | Start here                                        |
-| ----------------------------- | ------------------------------------------------- |
+|-------------------------------|---------------------------------------------------|
 | A guided local setup          | `npm create awesome-node-app@latest my-app`       |
 | A repeatable CI/platform flow | `--no-interactive` with explicit flags            |
 | Your company starter          | `--template <github-url>` or `--template file://` |
@@ -56,11 +56,11 @@ npx create-awesome-node-app my-app \
 
 ## ✨ Why CNA?
 
-| Capability                       | Value                                                                                                 |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| 🧩 **Composable by design**      | Start with a template, then layer only the addons your project actually needs.                        |
+| Capability                        | Value                                                                                                 |
+|-----------------------------------|-------------------------------------------------------------------------------------------------------|
+| 🧩 **Composable by design**       | Start with a template, then layer only the addons your project actually needs.                        |
 | 🛡️ **Production-ready defaults** | TypeScript, linting, scripts, testing paths, and practical DX defaults out of the box.                |
-| 🤖 **AI-ready from day one**     | Supported templates generate `AGENTS.md` so coding agents understand the project context.             |
+| 🤖 **AI-ready from day one**      | Supported templates generate `AGENTS.md` so coding agents understand the project context.             |
 | 🏗️ **CI and platform friendly**  | Use `--no-interactive`, `--set`, `--template <url>`, and `--extend <url>` for repeatable scaffolding. |
 
 ---
@@ -80,7 +80,7 @@ You can mix catalog templates and addons with your own GitHub or `file://` sourc
 ### 🧱 Template Families
 
 | Category      | Example templates                                           |
-| ------------- | ----------------------------------------------------------- |
+|---------------|-------------------------------------------------------------|
 | Frontend      | `react-vite-boilerplate`, `astro-starter`                   |
 | Backend       | `nestjs-boilerplate`, `hono-starter`                        |
 | Full Stack    | `nextjs-starter`, `nextjs-saas-ai-starter`, `remix-starter` |
@@ -91,7 +91,7 @@ You can mix catalog templates and addons with your own GitHub or `file://` sourc
 ### 🧰 Addon Families
 
 | Category                  | Examples                                                                  |
-| ------------------------- | ------------------------------------------------------------------------- |
+|---------------------------|---------------------------------------------------------------------------|
 | UI                        | `tailwind-css`, `material-ui`, `shadcn-ui`, `nextjs-shadcn`               |
 | State and data            | `zustand`, `jotai`, `tanstack-react-query`, `apollo-client`               |
 | Backend and DB            | `drizzle-orm-postgresql`, `drizzle-orm-sqlite`, `mongoose-orm-mongodb`    |
@@ -215,7 +215,7 @@ Full catalog:
 Supported templates can generate an `AGENTS.md` file so coding assistants understand project context before editing:
 
 | Context                | Why it matters                                              |
-| ---------------------- | ----------------------------------------------------------- |
+|------------------------|-------------------------------------------------------------|
 | Project purpose        | Agents understand what the app is for before changing code. |
 | Directory layout       | Suggestions align with the real structure.                  |
 | Scripts and validation | Agents know how to lint, test, build, and verify changes.   |
@@ -230,7 +230,7 @@ Learn more: **[AGENTS.md guide](https://create-awesome-node-app.vercel.app/docs/
 Run the CLI without flags and CNA guides you through:
 
 | Step              | What you choose                                                            |
-| ----------------- | -------------------------------------------------------------------------- |
+|-------------------|----------------------------------------------------------------------------|
 | Project name      | Confirm or set the target directory                                        |
 | Package manager   | npm, yarn, pnpm, or Bun                                                    |
 | Category          | Frontend, Backend, Full Stack, Monorepo, Web Extension, UAT, or custom URL |
@@ -261,7 +261,7 @@ Usage: create-awesome-node-app [project-directory] [options]
 ```
 
 | Flag                         | Description                                           |
-| ---------------------------- | ----------------------------------------------------- |
+|------------------------------|-------------------------------------------------------|
 | `--interactive`              | Force interactive wizard (default outside CI)         |
 | `--no-interactive`           | Disable wizard and use flags only                     |
 | `-t, --template <slug\|url>` | Template slug from catalog or remote/local URL        |
@@ -328,7 +328,7 @@ cache lives at `~/.cache/cna` by default; override with `--cache-dir
 <path>` or `CNA_CACHE_DIR`.
 
 | Path                            | Contents                                   |
-| ------------------------------- | ------------------------------------------ |
+|---------------------------------|--------------------------------------------|
 | `~/.cache/cna/catalog/`         | Cached `templates.json` (one file)         |
 | `~/.cache/cna/<base64-of-url>/` | Shallow clone of one template or extension |
 

--- a/packages/create-awesome-node-app/README.md
+++ b/packages/create-awesome-node-app/README.md
@@ -46,7 +46,7 @@ npx create-awesome-node-app my-app \
 ```
 
 | If you want...                | Start here                                        |
-|-------------------------------|---------------------------------------------------|
+| ----------------------------- | ------------------------------------------------- |
 | A guided local setup          | `npm create awesome-node-app@latest my-app`       |
 | A repeatable CI/platform flow | `--no-interactive` with explicit flags            |
 | Your company starter          | `--template <github-url>` or `--template file://` |
@@ -56,11 +56,11 @@ npx create-awesome-node-app my-app \
 
 ## ✨ Why CNA?
 
-| Capability                        | Value                                                                                                 |
-|-----------------------------------|-------------------------------------------------------------------------------------------------------|
-| 🧩 **Composable by design**       | Start with a template, then layer only the addons your project actually needs.                        |
+| Capability                       | Value                                                                                                 |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| 🧩 **Composable by design**      | Start with a template, then layer only the addons your project actually needs.                        |
 | 🛡️ **Production-ready defaults** | TypeScript, linting, scripts, testing paths, and practical DX defaults out of the box.                |
-| 🤖 **AI-ready from day one**      | Supported templates generate `AGENTS.md` so coding agents understand the project context.             |
+| 🤖 **AI-ready from day one**     | Supported templates generate `AGENTS.md` so coding agents understand the project context.             |
 | 🏗️ **CI and platform friendly**  | Use `--no-interactive`, `--set`, `--template <url>`, and `--extend <url>` for repeatable scaffolding. |
 
 ---
@@ -80,7 +80,7 @@ You can mix catalog templates and addons with your own GitHub or `file://` sourc
 ### 🧱 Template Families
 
 | Category      | Example templates                                           |
-|---------------|-------------------------------------------------------------|
+| ------------- | ----------------------------------------------------------- |
 | Frontend      | `react-vite-boilerplate`, `astro-starter`                   |
 | Backend       | `nestjs-boilerplate`, `hono-starter`                        |
 | Full Stack    | `nextjs-starter`, `nextjs-saas-ai-starter`, `remix-starter` |
@@ -91,7 +91,7 @@ You can mix catalog templates and addons with your own GitHub or `file://` sourc
 ### 🧰 Addon Families
 
 | Category                  | Examples                                                                  |
-|---------------------------|---------------------------------------------------------------------------|
+| ------------------------- | ------------------------------------------------------------------------- |
 | UI                        | `tailwind-css`, `material-ui`, `shadcn-ui`, `nextjs-shadcn`               |
 | State and data            | `zustand`, `jotai`, `tanstack-react-query`, `apollo-client`               |
 | Backend and DB            | `drizzle-orm-postgresql`, `drizzle-orm-sqlite`, `mongoose-orm-mongodb`    |
@@ -215,7 +215,7 @@ Full catalog:
 Supported templates can generate an `AGENTS.md` file so coding assistants understand project context before editing:
 
 | Context                | Why it matters                                              |
-|------------------------|-------------------------------------------------------------|
+| ---------------------- | ----------------------------------------------------------- |
 | Project purpose        | Agents understand what the app is for before changing code. |
 | Directory layout       | Suggestions align with the real structure.                  |
 | Scripts and validation | Agents know how to lint, test, build, and verify changes.   |
@@ -230,7 +230,7 @@ Learn more: **[AGENTS.md guide](https://create-awesome-node-app.vercel.app/docs/
 Run the CLI without flags and CNA guides you through:
 
 | Step              | What you choose                                                            |
-|-------------------|----------------------------------------------------------------------------|
+| ----------------- | -------------------------------------------------------------------------- |
 | Project name      | Confirm or set the target directory                                        |
 | Package manager   | npm, yarn, pnpm, or Bun                                                    |
 | Category          | Frontend, Backend, Full Stack, Monorepo, Web Extension, UAT, or custom URL |
@@ -261,7 +261,7 @@ Usage: create-awesome-node-app [project-directory] [options]
 ```
 
 | Flag                         | Description                                           |
-|------------------------------|-------------------------------------------------------|
+| ---------------------------- | ----------------------------------------------------- |
 | `--interactive`              | Force interactive wizard (default outside CI)         |
 | `--no-interactive`           | Disable wizard and use flags only                     |
 | `-t, --template <slug\|url>` | Template slug from catalog or remote/local URL        |
@@ -275,10 +275,89 @@ Usage: create-awesome-node-app [project-directory] [options]
 | `--use-bun`                  | Use Bun instead of npm, yarn, or pnpm                 |
 | `--list-templates`           | Print all templates grouped by category               |
 | `--list-addons`              | Print addons, optionally filtered by `--template`     |
+| `--offline`                  | Use the local cache only; do not refresh templates    |
+| `--no-cache`                 | Disable the catalog cache; force a refresh each run   |
+| `--cache-dir <path>`         | Override the cache root (default: `~/.cache/cna`)     |
+| `--refresh <mode>`           | When to refresh: `always` \| `stale` \| `manual`      |
 | `-v, --verbose`              | Output resolved generation config as JSON             |
 | `-i, --info`                 | Print Node, npm, and OS diagnostics                   |
 | `-V, --version`              | Print CLI version                                     |
 | `-h, --help`                 | Show help                                             |
+
+### 🗃️ `cna cache` subcommand
+
+```text
+Usage: create-awesome-node-app cache [options] [command]
+
+Commands:
+  dir                   Print the cache root directory
+  list                  List cached templates and extensions
+  clean [id]            Remove one or all entries; --catalog also clears the catalog cache
+  verify [id]           Run `git fsck` on one or all entries
+```
+
+Inspect and manage the on-disk cache:
+
+```bash
+# Where is my cache?
+npx create-awesome-node-app cache dir
+# /home/<you>/.cache/cna
+
+# What's in it?
+npx create-awesome-node-app cache list
+# ID  URL                                BRANCH  LAST FETCHED  SHA       SIZE
+# ...<base64-id>  https://github.com/...  main    3h ago       abc1234   9.3 MB
+
+# Verify integrity
+npx create-awesome-node-app cache verify
+
+# Clear everything (and the catalog cache)
+npx create-awesome-node-app cache clean --catalog
+
+# Clear a single entry by its base64 ID
+npx create-awesome-node-app cache clean <id>
+```
+
+---
+
+## 📦 Cache & Updates
+
+CNA caches both the **template catalog** (`templates.json` from
+`raw.githubusercontent.com`) and the **template git repos** themselves. The
+cache lives at `~/.cache/cna` by default; override with `--cache-dir
+<path>` or `CNA_CACHE_DIR`.
+
+| Path                            | Contents                                   |
+| ------------------------------- | ------------------------------------------ |
+| `~/.cache/cna/catalog/`         | Cached `templates.json` (one file)         |
+| `~/.cache/cna/<base64-of-url>/` | Shallow clone of one template or extension |
+
+### Refresh modes (set with `--refresh <mode>` or `CNA_REFRESH=<mode>`)
+
+- **`stale`** (default): pull only when the cache is older than
+  `CNA_REFRESH_AFTER_HOURS` (default `24`). No network on a warm cache.
+- **`always`**: pull on every run (the pre-Phase-2 behavior).
+- **`manual`**: never pull unless `--refresh` is passed.
+
+Each cache entry has a `.cna-meta.json` sidecar with `lastFetchedAt`,
+`lastCommitSha`, `lastRefreshReason`, `branch`, and `url`.
+
+### CI and offline usage
+
+```bash
+# Fully offline CI: use the local cache only, no network.
+npx create-awesome-node-app my-app -t react-vite-boilerplate --offline
+
+# Pin the cache to a project-local directory (useful in monorepos and CI).
+CNA_CACHE_DIR="$PWD/.cna-cache" npx create-awesome-node-app my-app -t react-vite-boilerplate
+```
+
+### Storage optimization
+
+On a cache hit, the working copy is built with `cp -c` (reflink) when the
+filesystem supports it, then `cp -l` (hardlink) on Linux, then a recursive
+copy as a last resort. A warm scaffold is O(1) on the working directory
+when reflinks are available.
 
 ---
 

--- a/packages/create-awesome-node-app/package.json
+++ b/packages/create-awesome-node-app/package.json
@@ -76,7 +76,6 @@
   },
   "dependencies": {
     "@create-node-app/core": "^0.6.10",
-    "axios": "^1.18.1",
     "ci-info": "^4.4.0",
     "commander": "^15.0.0",
     "picocolors": "^1.1.1",

--- a/packages/create-awesome-node-app/src/cache-cli.ts
+++ b/packages/create-awesome-node-app/src/cache-cli.ts
@@ -1,0 +1,137 @@
+import pc from "picocolors";
+import {
+  cleanCache,
+  getCacheRoot,
+  listCacheEntries,
+  verifyCache,
+} from "./cache.js";
+import { getCatalogCacheFilePath } from "./templates.js";
+import { existsSync, rmSync } from "fs";
+
+const formatBytes = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+};
+
+const formatAge = (iso: string | undefined): string => {
+  if (!iso) return pc.dim("—");
+  const ms = Date.now() - Date.parse(iso);
+  if (Number.isNaN(ms)) return pc.dim("?");
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+};
+
+const shortSha = (sha: string | undefined): string => {
+  if (!sha) return pc.dim("—");
+  return sha.slice(0, 7);
+};
+
+export const cacheDir = (): void => {
+  console.log(getCacheRoot());
+};
+
+export const cacheList = async (): Promise<void> => {
+  const entries = await listCacheEntries();
+  if (entries.length === 0) {
+    console.log(pc.dim("No cached templates or extensions."));
+    console.log(
+      pc.dim(
+        `Cache root: ${getCacheRoot()}\nRun 'npx create-awesome-node-app my-app -t <template>' to populate it.`,
+      ),
+    );
+    return;
+  }
+  const idWidth = Math.max(2, ...entries.map((e) => e.id.length));
+  console.log(
+    [
+      "ID".padEnd(idWidth),
+      pc.dim("URL".padEnd(50)),
+      pc.dim("BRANCH".padEnd(8)),
+      pc.dim("LAST FETCHED".padEnd(14)),
+      pc.dim("SHA".padEnd(8)),
+      pc.dim("SIZE"),
+    ].join("  "),
+  );
+  for (const entry of entries) {
+    console.log(
+      [
+        pc.cyan(entry.id),
+        pc.dim((entry.url ?? "—").padEnd(50).slice(0, 50)),
+        pc.dim((entry.branch ?? "—").padEnd(8)),
+        pc.dim(formatAge(entry.lastFetchedAt).padEnd(14)),
+        pc.dim(shortSha(entry.lastCommitSha)),
+        pc.dim(formatBytes(entry.sizeBytes ?? 0)),
+      ].join("  "),
+    );
+  }
+  console.log(pc.dim(`\nCache root: ${getCacheRoot()}`));
+};
+
+export const cacheClean = async (
+  id?: string,
+  options: { catalog?: boolean } = {},
+): Promise<void> => {
+  if (options.catalog) {
+    const file = getCatalogCacheFilePath();
+    if (existsSync(file)) {
+      rmSync(file);
+      console.log(pc.green(`✓ Removed catalog cache: ${file}`));
+    } else {
+      console.log(pc.dim("No catalog cache to remove."));
+    }
+    return;
+  }
+  if (id) {
+    const result = await cleanCache(id);
+    if (result.notFound.length > 0) {
+      console.log(pc.yellow(`No cache entry found for id: ${id}`));
+      return;
+    }
+    for (const p of result.removed) {
+      console.log(pc.green(`✓ Removed ${p}`));
+    }
+    return;
+  }
+  const result = await cleanCache();
+  if (result.removed.length === 0) {
+    console.log(pc.dim("Nothing to remove."));
+  } else {
+    for (const p of result.removed) {
+      console.log(pc.green(`✓ Removed ${p}`));
+    }
+  }
+};
+
+export const cacheVerify = async (id?: string): Promise<number> => {
+  const results = await verifyCache(id);
+  if (results.length === 0) {
+    console.log(pc.dim("No cached entries."));
+    return 0;
+  }
+  let allOk = true;
+  for (const entry of results) {
+    const ok = entry.fsckOk;
+    if (!ok) allOk = false;
+    console.log(
+      `${ok ? pc.green("✓") : pc.red("✗")} ${pc.cyan(entry.id)}  ${pc.dim(entry.url ?? "—")}`,
+    );
+  }
+  if (!allOk) {
+    console.log();
+    console.log(
+      pc.red(
+        "Some entries failed git fsck. Consider 'cna cache clean' and re-run.",
+      ),
+    );
+    return 1;
+  }
+  return 0;
+};

--- a/packages/create-awesome-node-app/src/cache.ts
+++ b/packages/create-awesome-node-app/src/cache.ts
@@ -1,0 +1,193 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { execFileSync } from "child_process";
+import { readFile, writeFile, mkdir, rm } from "fs/promises";
+
+/**
+ * Resolve the cache root directory. Honors `CNA_CACHE_DIR` env var.
+ */
+export const getCacheRoot = (): string => {
+  const override = process.env.CNA_CACHE_DIR;
+  if (override && override.length > 0) {
+    return path.isAbsolute(override) ? override : path.resolve(override);
+  }
+  return path.join(os.homedir(), ".cache", "cna");
+};
+
+export type CacheEntryMeta = {
+  /** base64-of-<gitUrl>@<branch> (targetId from downloadRepository) */
+  id: string;
+  /** absolute path to the cache directory on disk */
+  path: string;
+  /** last fetch timestamp (ISO), if .cna-meta.json is present */
+  lastFetchedAt?: string | undefined;
+  /** last commit SHA, if recorded */
+  lastCommitSha?: string | undefined;
+  /** reason for the last refresh */
+  lastRefreshReason?: string | undefined;
+  /** branch recorded in the meta sidecar */
+  branch?: string | undefined;
+  /** upstream URL recorded in the meta sidecar */
+  url?: string | undefined;
+  /** approximate size of the entry in bytes (sum of file sizes) */
+  sizeBytes?: number | undefined;
+  /** whether `git fsck` reports the entry as clean */
+  fsckOk?: boolean | undefined;
+};
+
+type ReadMetaResult = {
+  lastFetchedAt?: string | undefined;
+  lastCommitSha?: string | undefined;
+  lastRefreshReason?: string | undefined;
+  branch?: string | undefined;
+  url?: string | undefined;
+};
+
+const readMetaSidecar = async (entryPath: string): Promise<ReadMetaResult> => {
+  const metaPath = path.join(entryPath, ".cna-meta.json");
+  try {
+    const raw = await readFile(metaPath, "utf8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return {
+      lastFetchedAt:
+        typeof parsed.lastFetchedAt === "string"
+          ? parsed.lastFetchedAt
+          : undefined,
+      lastCommitSha:
+        typeof parsed.lastCommitSha === "string"
+          ? parsed.lastCommitSha
+          : undefined,
+      lastRefreshReason:
+        typeof parsed.lastRefreshReason === "string"
+          ? parsed.lastRefreshReason
+          : undefined,
+      branch: typeof parsed.branch === "string" ? parsed.branch : undefined,
+      url: typeof parsed.url === "string" ? parsed.url : undefined,
+    };
+  } catch {
+    return {};
+  }
+};
+
+const dirSize = (dir: string): number => {
+  let total = 0;
+  const stack: string[] = [dir];
+  while (stack.length > 0) {
+    const current = stack.pop() as string;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(entryPath);
+      } else if (entry.isFile()) {
+        try {
+          total += fs.statSync(entryPath).size;
+        } catch {
+          // ignore unreadable
+        }
+      }
+    }
+  }
+  return total;
+};
+
+const runGitFsck = (entryPath: string): boolean => {
+  try {
+    execFileSync("git", ["fsck", "--no-progress"], {
+      cwd: entryPath,
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const listCacheEntries = async (): Promise<CacheEntryMeta[]> => {
+  const root = getCacheRoot();
+  if (!fs.existsSync(root)) return [];
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: CacheEntryMeta[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const entryPath = path.join(root, entry.name);
+    // Skip the catalog subdirectory (managed by templates.ts).
+    if (entry.name === "catalog") continue;
+    const meta = await readMetaSidecar(entryPath);
+    out.push({
+      id: entry.name,
+      path: entryPath,
+      ...meta,
+      sizeBytes: dirSize(entryPath),
+    });
+  }
+  return out;
+};
+
+export const cleanCache = async (
+  id?: string,
+): Promise<{
+  removed: string[];
+  notFound: string[];
+}> => {
+  const root = getCacheRoot();
+  if (id) {
+    const target = path.join(root, id);
+    if (!fs.existsSync(target)) {
+      return { removed: [], notFound: [id] };
+    }
+    await rm(target, { recursive: true, force: true });
+    return { removed: [target], notFound: [] };
+  }
+  if (!fs.existsSync(root)) {
+    return { removed: [], notFound: [] };
+  }
+  const removed: string[] = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const target = path.join(root, entry.name);
+    await rm(target, { recursive: true, force: true });
+    removed.push(target);
+  }
+  return { removed, notFound: [] };
+};
+
+export const verifyCache = async (id?: string): Promise<CacheEntryMeta[]> => {
+  const entries = await listCacheEntries();
+  const target = id ? entries.filter((e) => e.id === id) : entries;
+  return target.map((entry) => ({
+    ...entry,
+    fsckOk: runGitFsck(entry.path),
+  }));
+};
+
+/**
+ * Persist the template catalog to the on-disk cache. Used by templates.ts
+ * so that a `cache list` shows the catalog timestamp too.
+ */
+export const writeCatalogToCache = async (
+  data: unknown,
+  cacheFile: string,
+): Promise<void> => {
+  await mkdir(path.dirname(cacheFile), { recursive: true });
+  await writeFile(cacheFile, JSON.stringify(data), "utf8");
+};
+
+/**
+ * Remove the on-disk catalog cache. Used by `cna cache clean --catalog`
+ * and by tests.
+ */
+export const removeCatalogCache = async (cacheFile: string): Promise<void> => {
+  await rm(cacheFile, { force: true });
+};

--- a/packages/create-awesome-node-app/src/index.ts
+++ b/packages/create-awesome-node-app/src/index.ts
@@ -13,6 +13,7 @@ import { parseSetOverrides } from "./set-overrides.js";
 // NodeNext JSON import with import attributes
 import packageJson from "../package.json" with { type: "json" };
 import { listTemplates, listAddons } from "./list.js";
+import { cacheClean, cacheDir, cacheList, cacheVerify } from "./cache-cli.js";
 // Re-export template helpers for testing / programmatic use
 export {
   getTemplateCategories,
@@ -24,6 +25,47 @@ const program = new Command();
 
 const main = async () => {
   let projectName = "my-project";
+  let cacheSubcommand: string | undefined;
+  let cacheSubcommandArg: string | undefined;
+  let cacheCatalogFlag = false;
+
+  const cacheCommand = program
+    .command("cache")
+    .description("Inspect and manage the local template/extension cache");
+
+  cacheCommand
+    .command("dir")
+    .description("Print the cache root directory")
+    .action(() => {
+      cacheSubcommand = "dir";
+    });
+
+  cacheCommand
+    .command("list")
+    .description("List cached templates and extensions")
+    .action(() => {
+      cacheSubcommand = "list";
+    });
+
+  cacheCommand
+    .command("clean [id]")
+    .description(
+      "Remove one or all cached entries (pass --catalog to also clear the template catalog cache)",
+    )
+    .option("--catalog", "Also clear the on-disk template catalog cache")
+    .action((id: string | undefined, options: { catalog?: boolean }) => {
+      cacheSubcommand = "clean";
+      cacheSubcommandArg = id;
+      cacheCatalogFlag = Boolean(options.catalog);
+    });
+
+  cacheCommand
+    .command("verify [id]")
+    .description("Run git fsck on one or all cached entries")
+    .action((id: string | undefined) => {
+      cacheSubcommand = "verify";
+      cacheSubcommandArg = id;
+    });
 
   program
     .version(packageJson.version)
@@ -66,11 +108,55 @@ const main = async () => {
       "--set <assignments...>",
       "set a custom template option (format: key=value; quote values with spaces: --set 'projectName=My App' or --set 'projectName=My App' --set 'author=Jane Doe')",
     )
+    .option(
+      "--offline",
+      "use the local cache only; do not refresh templates from the network",
+    )
+    .option(
+      "--no-cache",
+      "disable the on-disk cache and always re-download templates (sets CNA_NO_CATALOG_CACHE=1 and forces refresh=always)",
+    )
+    .option(
+      "--cache-dir <path>",
+      "override the cache root (defaults to ~/.cache/cna; also CNA_CACHE_DIR)",
+    )
+    .option(
+      "--refresh <mode>",
+      "when to refresh the cached template: always | stale | manual (default: stale)",
+      (value: string) => {
+        if (!["always", "stale", "manual"].includes(value)) {
+          throw new Error(
+            `Invalid --refresh mode: '${value}'. Use one of: always, stale, manual.`,
+          );
+        }
+        return value as "always" | "stale" | "manual";
+      },
+    )
     .action((providedProjectName: string | undefined) => {
       projectName = providedProjectName || projectName;
     });
 
   program.parse(process.argv);
+
+  // Handle cache subcommands before the regular flow.
+  if (cacheSubcommand) {
+    switch (cacheSubcommand) {
+      case "dir":
+        cacheDir();
+        return;
+      case "list":
+        await cacheList();
+        return;
+      case "clean":
+        await cacheClean(cacheSubcommandArg, { catalog: cacheCatalogFlag });
+        return;
+      case "verify": {
+        const code = await cacheVerify(cacheSubcommandArg);
+        if (code !== 0) process.exit(code);
+        return;
+      }
+    }
+  }
 
   const opts = program.opts();
   checkNodeVersion(packageJson.engines.node, packageJson.name);
@@ -100,8 +186,19 @@ const main = async () => {
     return;
   }
 
+  // Translate --no-cache into the two env vars that downstream code reads.
+  if (opts.noCache) {
+    process.env.CNA_NO_CATALOG_CACHE = "1";
+    if (!opts.refresh) {
+      opts.refresh = "always";
+    }
+  }
+  if (opts.cacheDir) {
+    process.env.CNA_CACHE_DIR = opts.cacheDir;
+  }
+
   // Extract package manager options directly from opts
-  const { useYarn, usePnpm, useBun, set, ...restOpts } = opts;
+  const { useYarn, usePnpm, useBun, set, noCache, ...restOpts } = opts;
   const packageManager = useYarn
     ? "yarn"
     : usePnpm
@@ -121,10 +218,17 @@ const main = async () => {
       return acc.concat({ url: templateOrExtension });
     }, [] as TemplateOrExtension[]);
 
+  // `noCache` is consumed above (translates to env + refresh=always);
+  // `cacheDir` similarly. Strip both from the rest spread so they don't
+  // leak into the EJS context via the catch-all object.
+  const { cacheDir: _cacheDirFlag, ...scaffoldOpts } = restOpts;
+  void noCache;
+  void _cacheDirFlag;
+
   return createNodeApp(
     projectName,
     {
-      ...restOpts,
+      ...scaffoldOpts,
       packageManager,
       templatesOrExtensions,
       projectName,

--- a/packages/create-awesome-node-app/src/templates.ts
+++ b/packages/create-awesome-node-app/src/templates.ts
@@ -1,8 +1,28 @@
-import axios from "axios";
 import type { PromptType } from "prompts";
+import { readFile } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import os from "os";
 
 const TEMPLATE_DATA_FILE_URL =
   "https://raw.githubusercontent.com/Create-Node-App/cna-templates/main/templates.json";
+
+export const CNA_USER_AGENT = `create-awesome-node-app/0.9.9 (https://github.com/Create-Node-App/create-node-app)`;
+export const CNA_FETCH_TIMEOUT_MS = 10_000;
+export const CACHE_TTL_MS = 3600000; // 1 hour
+
+export const getCatalogCacheDir = (): string => {
+  const override = process.env.CNA_CACHE_DIR;
+  const base =
+    override && override.length > 0
+      ? override
+      : path.join(os.homedir(), ".cache", "cna");
+  return path.join(base, "catalog");
+};
+
+export const getCatalogCacheFilePath = (): string => {
+  return path.join(getCatalogCacheDir(), "templates.json");
+};
 
 export type TemplateOrExtensionData = {
   name: string;
@@ -42,36 +62,97 @@ export type Templates = {
   categories: CategoryData[];
 };
 
-const CACHE_TTL_MS = 3600000; // Cache data for 1 hour
-
 const templateDataCache = {
   data: null as Templates | null,
   timestamp: 0,
 };
 
-const fetchTemplateData = async () => {
+const readCachedCatalogFromDisk = async (): Promise<Templates | null> => {
+  const filePath = getCatalogCacheFilePath();
+  if (!existsSync(filePath)) return null;
   try {
-    const response = await axios.get<Templates>(TEMPLATE_DATA_FILE_URL);
-    return response.data;
+    const raw = await readFile(filePath, "utf8");
+    return JSON.parse(raw) as Templates;
   } catch {
-    // Handle network error, e.g., log it or show a user-friendly message.
-    throw new Error("Failed to fetch template data");
+    return null;
   }
 };
 
-const getTemplateData = async () => {
-  const currentTime = Date.now();
+const writeCatalogToDisk = async (data: Templates): Promise<void> => {
+  const dir = getCatalogCacheDir();
+  const filePath = getCatalogCacheFilePath();
+  try {
+    const { mkdir } = await import("fs/promises");
+    await mkdir(dir, { recursive: true });
+    const { writeFile } = await import("fs/promises");
+    await writeFile(filePath, JSON.stringify(data), "utf8");
+  } catch {
+    // Best-effort; disk cache is an optimization.
+  }
+};
 
-  if (
-    templateDataCache.data === null ||
-    currentTime - templateDataCache.timestamp > CACHE_TTL_MS
-  ) {
-    // Data is not in cache or has expired, fetch and cache it.
-    templateDataCache.data = await fetchTemplateData();
-    templateDataCache.timestamp = currentTime;
+const fetchTemplateData = async (): Promise<Templates> => {
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      CNA_FETCH_TIMEOUT_MS,
+    );
+    try {
+      const response = await fetch(TEMPLATE_DATA_FILE_URL, {
+        headers: {
+          Accept: "application/json",
+          "User-Agent": CNA_USER_AGENT,
+        },
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} ${response.statusText}`);
+      }
+      return (await response.json()) as Templates;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  } catch (err) {
+    // Fall back to disk cache if network is unavailable.
+    const disk = await readCachedCatalogFromDisk();
+    if (disk) {
+      console.warn(
+        `[cna] Could not refresh template catalog (${err instanceof Error ? err.message : String(err)}). Using cached version.`,
+      );
+      return disk;
+    }
+    throw new Error(
+      `Failed to fetch template data: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+};
+
+const isCacheFresh = (): boolean => {
+  if (templateDataCache.data === null) return false;
+  if (process.env.CNA_NO_CATALOG_CACHE === "1") return false;
+  return Date.now() - templateDataCache.timestamp <= CACHE_TTL_MS;
+};
+
+export const getTemplateData = async (): Promise<Templates> => {
+  if (isCacheFresh()) {
+    return templateDataCache.data as Templates;
   }
 
-  return templateDataCache.data;
+  const data = await fetchTemplateData();
+  templateDataCache.data = data;
+  templateDataCache.timestamp = Date.now();
+  // Persist to disk so subsequent invocations can fall back when offline.
+  // Awaited so callers (and tests) can rely on the file existing after
+  // getTemplateData() resolves.
+  await writeCatalogToDisk(data);
+  return data;
+};
+
+// Test-only: reset the in-memory cache.
+export const __resetTemplateDataCacheForTests = () => {
+  templateDataCache.data = null;
+  templateDataCache.timestamp = 0;
 };
 
 export const getTemplateCategories = async (

--- a/packages/create-awesome-node-app/tests/cache.test.mts
+++ b/packages/create-awesome-node-app/tests/cache.test.mts
@@ -1,0 +1,165 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { execFileSync } from "child_process";
+import {
+  cleanCache,
+  getCacheRoot,
+  listCacheEntries,
+  verifyCache,
+  writeCatalogToCache,
+} from "../src/cache.js";
+import { writeCacheMeta } from "@create-node-app/core";
+import { getCatalogCacheFilePath } from "../src/templates.js";
+
+const makeTempDir = (): string => {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "cna-cache-test-"));
+};
+
+const initGitRepo = (dir: string): void => {
+  execFileSync("git", ["init", "--initial-branch=main", dir], {
+    stdio: "ignore",
+  });
+  execFileSync("git", ["config", "user.email", "test@example.com"], {
+    cwd: dir,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["config", "user.name", "Test"], {
+    cwd: dir,
+    stdio: "ignore",
+  });
+  fs.writeFileSync(path.join(dir, "README.md"), "hi\n");
+  execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "init"], {
+    cwd: dir,
+    stdio: "ignore",
+  });
+};
+
+const cleanup = (dir: string): void => {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+};
+
+async function withTempCnaCacheDir<T>(
+  fn: (cacheRoot: string) => Promise<T> | void,
+): Promise<T | void> {
+  const dir = makeTempDir();
+  process.env.CNA_CACHE_DIR = dir;
+  try {
+    return await fn(dir);
+  } finally {
+    delete process.env.CNA_CACHE_DIR;
+    cleanup(dir);
+  }
+}
+
+test("getCacheRoot honors CNA_CACHE_DIR", async () => {
+  await withTempCnaCacheDir((root) => {
+    assert.equal(getCacheRoot(), root);
+  });
+});
+
+test("listCacheEntries returns empty for a fresh cache root", async () => {
+  await withTempCnaCacheDir(async () => {
+    const entries = await listCacheEntries();
+    assert.deepEqual(entries, []);
+  });
+});
+
+test("listCacheEntries returns one entry per real cache directory", async () => {
+  await withTempCnaCacheDir(async (root) => {
+    const entryId = "test-entry";
+    const entryDir = path.join(root, entryId);
+    fs.mkdirSync(entryDir, { recursive: true });
+    initGitRepo(entryDir);
+    writeCacheMeta(entryDir, {
+      lastFetchedAt: "2026-01-01T00:00:00.000Z",
+      lastCommitSha: "deadbeef",
+      lastRefreshReason: "clone",
+      branch: "main",
+      url: "https://example.com/repo",
+    });
+    const entries = await listCacheEntries();
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0]?.id, entryId);
+    assert.equal(entries[0]?.url, "https://example.com/repo");
+    assert.equal(entries[0]?.branch, "main");
+    assert.equal(entries[0]?.lastCommitSha, "deadbeef");
+    assert.ok(entries[0]?.sizeBytes && entries[0].sizeBytes > 0);
+  });
+});
+
+test("listCacheEntries skips the catalog subdirectory", async () => {
+  await withTempCnaCacheDir(async (root) => {
+    fs.mkdirSync(path.join(root, "catalog"), { recursive: true });
+    const entries = await listCacheEntries();
+    assert.deepEqual(entries, []);
+  });
+});
+
+test("cleanCache with no id removes everything in the cache root", async () => {
+  await withTempCnaCacheDir(async (root) => {
+    const a = path.join(root, "a");
+    const b = path.join(root, "b");
+    fs.mkdirSync(a, { recursive: true });
+    fs.mkdirSync(b, { recursive: true });
+    initGitRepo(a);
+    initGitRepo(b);
+    const result = await cleanCache();
+    assert.equal(result.removed.length, 2);
+    assert.equal(result.notFound.length, 0);
+    assert.ok(!fs.existsSync(a));
+    assert.ok(!fs.existsSync(b));
+  });
+});
+
+test("cleanCache with id removes only that entry", async () => {
+  await withTempCnaCacheDir(async (root) => {
+    const a = path.join(root, "a");
+    const b = path.join(root, "b");
+    fs.mkdirSync(a, { recursive: true });
+    fs.mkdirSync(b, { recursive: true });
+    initGitRepo(a);
+    initGitRepo(b);
+    const result = await cleanCache("a");
+    assert.deepEqual(result.removed, [a]);
+    assert.equal(result.notFound.length, 0);
+    assert.ok(!fs.existsSync(a));
+    assert.ok(fs.existsSync(b));
+  });
+});
+
+test("cleanCache with unknown id reports notFound", async () => {
+  await withTempCnaCacheDir(async () => {
+    const result = await cleanCache("does-not-exist");
+    assert.equal(result.removed.length, 0);
+    assert.deepEqual(result.notFound, ["does-not-exist"]);
+  });
+});
+
+test("verifyCache runs git fsck and returns ok=true for a clean repo", async () => {
+  await withTempCnaCacheDir(async (root) => {
+    const a = path.join(root, "a");
+    fs.mkdirSync(a, { recursive: true });
+    initGitRepo(a);
+    const results = await verifyCache("a");
+    assert.equal(results.length, 1);
+    assert.equal(results[0]?.id, "a");
+    assert.equal(results[0]?.fsckOk, true);
+  });
+});
+
+test("writeCatalogToCache and getCatalogCacheFilePath integrate", async () => {
+  await withTempCnaCacheDir(async () => {
+    const file = getCatalogCacheFilePath();
+    await writeCatalogToCache({ templates: [], extensions: [] }, file);
+    const read = JSON.parse(fs.readFileSync(file, "utf8"));
+    assert.deepEqual(read, { templates: [], extensions: [] });
+  });
+});

--- a/packages/create-awesome-node-app/tests/templates-fetch.test.mts
+++ b/packages/create-awesome-node-app/tests/templates-fetch.test.mts
@@ -1,0 +1,133 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import nock from "nock";
+import {
+  __resetTemplateDataCacheForTests,
+  getTemplateData,
+  getCatalogCacheFilePath,
+  CNA_FETCH_TIMEOUT_MS,
+  CNA_USER_AGENT,
+} from "../src/templates.js";
+
+const makeTempDir = (): string => {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "cna-templates-test-"));
+};
+
+const cleanup = (dir: string): void => {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+};
+
+async function withTempCnaCacheDir<T>(
+  fn: () => Promise<T> | void,
+): Promise<T | void> {
+  const dir = makeTempDir();
+  process.env.CNA_CACHE_DIR = dir;
+  try {
+    return await fn();
+  } finally {
+    delete process.env.CNA_CACHE_DIR;
+    cleanup(dir);
+  }
+}
+
+const mockCatalog = {
+  templates: [
+    {
+      name: "Test",
+      slug: "test",
+      description: "Test template",
+      url: "https://example.com/test",
+      category: "test",
+      labels: ["test"],
+      type: "test",
+    },
+  ],
+  extensions: [],
+  categories: [
+    {
+      slug: "test",
+      name: "Test",
+      description: "Test category",
+      details: "",
+      labels: [],
+    },
+  ],
+};
+
+const setupNock = (): nock.Scope => {
+  return nock("https://raw.githubusercontent.com")
+    .get("/Create-Node-App/cna-templates/main/templates.json")
+    .reply(200, mockCatalog, {
+      "content-type": "application/json",
+    });
+};
+
+test("getTemplateData fetches and caches on first call", async () => {
+  await withTempCnaCacheDir(async () => {
+    __resetTemplateDataCacheForTests();
+    const scope = setupNock();
+    const data = await getTemplateData();
+    assert.equal(data.templates.length, 1);
+    assert.equal(data.templates[0]?.slug, "test");
+    assert.ok(scope.isDone());
+  });
+});
+
+test("getTemplateData persists to disk cache", async () => {
+  await withTempCnaCacheDir(async () => {
+    __resetTemplateDataCacheForTests();
+    setupNock();
+    await getTemplateData();
+    const file = getCatalogCacheFilePath();
+    assert.ok(fs.existsSync(file), "expected catalog cache file to exist");
+    const read = JSON.parse(fs.readFileSync(file, "utf8"));
+    assert.deepEqual(read, mockCatalog);
+  });
+});
+
+test("getTemplateData falls back to disk cache on network failure", async () => {
+  await withTempCnaCacheDir(async () => {
+    __resetTemplateDataCacheForTests();
+    // First call: prime the disk cache.
+    setupNock();
+    await getTemplateData();
+    // Second call: clear the in-memory cache, force a network failure
+    // (nock returns 500), and verify the disk cache is used.
+    __resetTemplateDataCacheForTests();
+    nock.cleanAll();
+    nock("https://raw.githubusercontent.com")
+      .get("/Create-Node-App/cna-templates/main/templates.json")
+      .reply(500, "boom");
+    const data = await getTemplateData();
+    assert.equal(data.templates.length, 1);
+    assert.equal(data.templates[0]?.slug, "test");
+  });
+});
+
+test("getTemplateData throws when network fails and no disk cache exists", async () => {
+  await withTempCnaCacheDir(async () => {
+    __resetTemplateDataCacheForTests();
+    // Force a 500 from nock so the call fails without doing real network.
+    nock.cleanAll();
+    nock("https://raw.githubusercontent.com")
+      .get("/Create-Node-App/cna-templates/main/templates.json")
+      .reply(500, "boom");
+    await assert.rejects(
+      () => getTemplateData(),
+      /Failed to fetch template data/,
+    );
+  });
+});
+
+test("constants are exported", () => {
+  assert.equal(typeof CNA_FETCH_TIMEOUT_MS, "number");
+  assert.equal(typeof CNA_USER_AGENT, "string");
+  assert.ok(CNA_USER_AGENT.includes("create-awesome-node-app"));
+});

--- a/packages/create-node-app-core/git.ts
+++ b/packages/create-node-app-core/git.ts
@@ -3,9 +3,11 @@ import path from "path";
 import fs from "fs";
 import debug from "debug";
 import { simpleGit, type SimpleGit, type CloneOptions } from "simple-git";
-import * as fse from "fs-extra"; // Import fs-extra for advanced file operations
+import * as fse from "fs-extra";
+import { execFileSync } from "child_process";
 
 const log = debug("cna:git");
+const metaLog = debug("cna:git:meta");
 
 const formatRepositoryDownloadError = (error: unknown, url: string): string => {
   const message = error instanceof Error ? error.message : String(error);
@@ -48,6 +50,8 @@ const filterGit = (src: string) => {
   return !/(\\|\/)\.git\b/.test(src);
 };
 
+export type RefreshMode = "always" | "stale" | "manual";
+
 export type DownloadRepositoryOptions = {
   url?: string;
   target: string;
@@ -55,6 +59,8 @@ export type DownloadRepositoryOptions = {
   branch?: string | undefined;
   offline?: boolean;
   targetId?: string;
+  refresh?: RefreshMode;
+  refreshAfterHours?: number;
 };
 
 // Create a Map to store ongoing Git operations
@@ -64,6 +70,165 @@ const gitOperationMap = new Map<string, Promise<void>>();
 const completedTargetIds = new Map<string, boolean>();
 
 /**
+ * Resolve the cache root directory. Honors `CNA_CACHE_DIR` env var and the
+ * `cacheDir` option, falling back to `~/.cache/cna/<id>`.
+ */
+export const resolveCacheDir = (id: string, optsCacheDir?: string): string => {
+  let base: string;
+  if (optsCacheDir) {
+    base = optsCacheDir;
+  } else if (process.env.CNA_CACHE_DIR) {
+    base = process.env.CNA_CACHE_DIR;
+  } else {
+    base = path.join(os.homedir(), ".cache", "cna");
+  }
+  const resolved = path.isAbsolute(base) ? base : path.resolve(base);
+  return path.join(resolved, id);
+};
+
+const metaSidecarPath = (cacheDir: string): string =>
+  path.join(cacheDir, ".cna-meta.json");
+
+export type CacheMeta = {
+  lastFetchedAt: string;
+  lastCommitSha?: string | undefined;
+  lastRefreshReason:
+    "clone" | "pull" | "stale-pull" | "manual-pull" | "skipped";
+  branch?: string | undefined;
+  url?: string | undefined;
+};
+
+export const readCacheMeta = (cacheDir: string): CacheMeta | null => {
+  try {
+    const raw = fs.readFileSync(metaSidecarPath(cacheDir), "utf8");
+    const parsed = JSON.parse(raw) as CacheMeta;
+    if (typeof parsed.lastFetchedAt !== "string") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+};
+
+export const writeCacheMeta = (cacheDir: string, meta: CacheMeta): void => {
+  try {
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(metaSidecarPath(cacheDir), JSON.stringify(meta, null, 2));
+    metaLog("wrote %s", metaSidecarPath(cacheDir));
+  } catch (err) {
+    metaLog("failed to write meta sidecar: %s", err);
+  }
+};
+
+const removeCacheMeta = (cacheDir: string): void => {
+  try {
+    fs.unlinkSync(metaSidecarPath(cacheDir));
+  } catch {
+    // ignore
+  }
+};
+
+const getCurrentCommitSha = (cacheDir: string): string | undefined => {
+  try {
+    const out = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: cacheDir,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return out.toString().trim();
+  } catch {
+    return undefined;
+  }
+};
+
+const DEFAULT_REFRESH_AFTER_HOURS = 24;
+
+const resolveRefreshMode = (
+  refresh: RefreshMode | undefined,
+  offline: boolean,
+): RefreshMode => {
+  if (offline) return "manual"; // offline implies no network calls
+  if (refresh) return refresh;
+  // Default: `stale` (was always). This is the new default.
+  if (process.env.CNA_REFRESH === "always") return "always";
+  if (process.env.CNA_REFRESH === "manual") return "manual";
+  return "stale";
+};
+
+const resolveRefreshAfterHours = (override?: number): number => {
+  if (typeof override === "number" && Number.isFinite(override)) {
+    return override;
+  }
+  const fromEnv = Number.parseFloat(process.env.CNA_REFRESH_AFTER_HOURS ?? "");
+  if (Number.isFinite(fromEnv) && fromEnv > 0) {
+    return fromEnv;
+  }
+  return DEFAULT_REFRESH_AFTER_HOURS;
+};
+
+const isStale = (meta: CacheMeta | null, thresholdHours: number): boolean => {
+  if (!meta) return true;
+  const lastFetched = Date.parse(meta.lastFetchedAt);
+  if (Number.isNaN(lastFetched)) return true;
+  const ageMs = Date.now() - lastFetched;
+  return ageMs > thresholdHours * 3600 * 1000;
+};
+
+/**
+ * Tree-clone with optional reflink/hardlink fallback. The `dest` directory
+ * is treated as a target: its existing contents are replaced with the
+ * contents of `source`. We achieve that by emptying `dest` first, then
+ * copying into it.
+ */
+const copyTree = async (
+  source: string,
+  dest: string,
+): Promise<"reflink" | "hardlink" | "copy"> => {
+  if (path.resolve(source) === path.resolve(dest)) {
+    return "copy";
+  }
+  // Empty the destination first. fs-extra's emptyDir exists but we use
+  // a manual implementation to keep dependencies tight.
+  if (fs.existsSync(dest)) {
+    for (const entry of fs.readdirSync(dest)) {
+      fs.rmSync(path.join(dest, entry), { recursive: true, force: true });
+    }
+  } else {
+    fs.mkdirSync(dest, { recursive: true });
+  }
+  // 1) Try reflink (cp -c) — only on Linux/macOS with FS support.
+  if (process.platform !== "win32") {
+    try {
+      // --no-target-directory treats `dest` as the target itself, not a
+      // parent — contents of `source` are copied INTO `dest`.
+      execFileSync(
+        "cp",
+        ["-c", "-R", "--reflink=auto", "--no-target-directory", source, dest],
+        { stdio: "ignore" },
+      );
+      log("copy: reflink ok");
+      return "reflink";
+    } catch (err) {
+      log("reflink failed (%s) — falling back to hardlink", err);
+    }
+    // 2) Try hardlink (cp -l) — only useful for files; for directories it
+    //    creates a tree where leaf files are hardlinks. Falls back to copy.
+    try {
+      execFileSync("cp", ["-R", "-l", "--no-target-directory", source, dest], {
+        stdio: "ignore",
+      });
+      log("copy: hardlink ok");
+      return "hardlink";
+    } catch (err) {
+      log("hardlink failed (%s) — falling back to recursive copy", err);
+    }
+  }
+  // 3) Fallback: full recursive copy (fse.copy handles nested dirs and
+  // overwrites in place).
+  await fse.copy(source, dest, { overwrite: true, filter: filterGit });
+  log("copy: recursive ok");
+  return "copy";
+};
+
+/**
  * @param opts options
  * @param opts.url The git repository url.
  * @param opts.targetId The target id. Default is `Buffer.from(`${gitUrl}@${branch}`).toString("base64")`
@@ -71,6 +236,8 @@ const completedTargetIds = new Map<string, boolean>();
  * @param opts.cacheDir? Default `~/.cache/cna/${name}`, the folder
  * @param opts.branch? Default 'main'. Git branch.
  * @param opts.offline? use cached files, and don't update.
+ * @param opts.refresh? one of "always" | "stale" | "manual". Default: "stale".
+ * @param opts.refreshAfterHours? override the staleness threshold (default 24).
  */
 export const downloadRepository = async ({
   url = "",
@@ -79,6 +246,8 @@ export const downloadRepository = async ({
   branch = "main",
   targetId,
   cacheDir: optsCacheDir,
+  refresh,
+  refreshAfterHours,
 }: DownloadRepositoryOptions) => {
   const absoluteTarget = path.isAbsolute(target)
     ? target
@@ -88,22 +257,19 @@ export const downloadRepository = async ({
   const isGithub = /^[^/]+\/[^/]+$/.test(url);
   const gitUrl = isGithub ? `https://github.com/${url}` : url;
   const id = targetId || Buffer.from(`${gitUrl}@${branch}`).toString("base64");
-  let cacheDir = optsCacheDir || path.join(os.homedir(), ".cache", "cna", id);
-
-  cacheDir = path.isAbsolute(cacheDir) ? cacheDir : path.resolve(cacheDir);
+  const cacheDir = resolveCacheDir(id, optsCacheDir);
 
   log("cache folder: %s", cacheDir);
+
+  const refreshMode = resolveRefreshMode(refresh, offline);
+  const thresholdHours = resolveRefreshAfterHours(refreshAfterHours);
 
   // Check if the targetId has already been completed (checkout done)
   if (completedTargetIds.has(id)) {
     log(
       `Git checkout for target ID '${id}' has already been completed. Skipping.`,
     );
-    // Use fs-extra's copy method with filter
-    await fse.copy(cacheDir, absoluteTarget, {
-      overwrite: true,
-      filter: filterGit,
-    });
+    await copyTree(cacheDir, absoluteTarget);
     return;
   }
 
@@ -128,26 +294,58 @@ export const downloadRepository = async ({
     };
 
     try {
-      const cached = fs.existsSync(cacheDir);
+      const cached =
+        fs.existsSync(cacheDir) && fs.existsSync(path.join(cacheDir, ".git"));
+      let didRefresh = false;
+      let refreshReason: CacheMeta["lastRefreshReason"] = "clone";
 
       if (!cached) {
+        if (offline) {
+          throw new Error(
+            `Cache miss and --offline: no cached copy of '${gitUrl}@${branch}' at ${cacheDir}.`,
+          );
+        }
         log("Cloning repository...");
         await git.clone(gitUrl, cacheDir, cloneOptions);
+        refreshReason = "clone";
+        didRefresh = true;
+      } else {
+        // Cache hit: decide whether to pull.
+        const meta = readCacheMeta(cacheDir);
+        const shouldPull =
+          refreshMode === "always" ||
+          (refreshMode === "stale" && isStale(meta, thresholdHours));
+
+        if (offline) {
+          log("cache hit (offline) — skipping pull");
+          refreshReason = "skipped";
+        } else if (!shouldPull) {
+          log("cache hit (fresh) — skipping pull");
+          refreshReason = "skipped";
+        } else {
+          log("Refreshing repository (mode=%s)...", refreshMode);
+          git = simpleGit(cacheDir);
+          await git.checkout(["-f", branch]);
+          await git.pull();
+          refreshReason =
+            refreshMode === "stale" ? "stale-pull" : "manual-pull";
+          didRefresh = true;
+        }
       }
 
-      git = simpleGit(cacheDir);
+      await copyTree(cacheDir, absoluteTarget);
 
-      if (!offline) {
-        log("Pulling repository...");
-        await git.checkout(["-f", branch]);
-        await git.pull();
+      if (didRefresh) {
+        const sha = getCurrentCommitSha(cacheDir);
+        const meta: CacheMeta = {
+          lastFetchedAt: new Date().toISOString(),
+          lastRefreshReason: refreshReason,
+          branch,
+          url: gitUrl,
+        };
+        if (sha) meta.lastCommitSha = sha;
+        writeCacheMeta(cacheDir, meta);
       }
-
-      // Use fs-extra's copy method with filter
-      await fse.copy(cacheDir, absoluteTarget, {
-        overwrite: true,
-        filter: filterGit,
-      });
 
       // Mark the targetId as completed
       completedTargetIds.set(id, true);
@@ -160,7 +358,14 @@ export const downloadRepository = async ({
           log("Failed to clean up directory: %s", cleanupErr);
         }
       }
-
+      // If the cache itself is corrupt, drop the meta sidecar so the next
+      // run can recover cleanly.
+      if (
+        error instanceof Error &&
+        /not a git repository|fatal: not/.test(error.message)
+      ) {
+        removeCacheMeta(cacheDir);
+      }
       throw new Error(formatRepositoryDownloadError(error, gitUrl));
     } finally {
       // Remove the promise from the map when the operation is complete
@@ -172,4 +377,10 @@ export const downloadRepository = async ({
 
   // Wait for the Git operation to complete
   await gitOperationPromise;
+};
+
+// Test-only: reset the in-process maps.
+export const __resetGitStateForTests = () => {
+  gitOperationMap.clear();
+  completedTargetIds.clear();
 };

--- a/packages/create-node-app-core/index.ts
+++ b/packages/create-node-app-core/index.ts
@@ -11,7 +11,13 @@ export {
   getTemplateDirPath,
   getTemplateBaseDirPath,
 } from "./paths.js";
-export { downloadRepository } from "./git.js";
+export {
+  downloadRepository,
+  writeCacheMeta,
+  readCacheMeta,
+  resolveCacheDir,
+} from "./git.js";
+export type { CacheMeta, RefreshMode } from "./git.js";
 export { loadTemplateCnaConfig } from "./config.js";
 export type { CnaConfig, CnaCustomOption } from "./config.js";
 export {
@@ -91,6 +97,10 @@ export type CnaOptions = {
   install?: boolean;
   template?: string;
   templatesOrExtensions?: TemplateOrExtension[];
+  offline?: boolean;
+  cacheDir?: string;
+  refresh?: import("./git.js").RefreshMode;
+  refreshAfterHours?: number;
 } & {
   [key: string]: unknown;
 };

--- a/packages/create-node-app-core/installer.ts
+++ b/packages/create-node-app-core/installer.ts
@@ -131,6 +131,10 @@ export type RunOptions = {
   installDependencies?: boolean;
   runCommand: string;
   installCommand: string;
+  offline?: boolean;
+  cacheDir?: string;
+  refresh?: import("./git.js").RefreshMode;
+  refreshAfterHours?: number;
 } & {
   [key: string]: unknown;
 };
@@ -202,6 +206,10 @@ const run = async ({
   installDependencies = true,
   runCommand = "",
   installCommand = "",
+  offline,
+  cacheDir,
+  refresh,
+  refreshAfterHours,
   ...customOptions
 }: RunOptions) => {
   const isOnline = useYarn ? await checkIfOnline(useYarn) : true;
@@ -231,6 +239,10 @@ const run = async ({
     useBun,
     runCommand,
     installCommand,
+    ...(offline !== undefined ? { offline } : {}),
+    ...(cacheDir !== undefined ? { cacheDir } : {}),
+    ...(refresh !== undefined ? { refresh } : {}),
+    ...(refreshAfterHours !== undefined ? { refreshAfterHours } : {}),
     ...customOptions,
   });
 
@@ -405,6 +417,10 @@ export type CreateAppOptions = {
   templatesOrExtensions?: TemplateOrExtension[];
   installDependencies?: boolean;
   ignorePackage?: boolean;
+  offline?: boolean;
+  cacheDir?: string;
+  refresh?: import("./git.js").RefreshMode;
+  refreshAfterHours?: number;
 } & {
   [key: string]: unknown;
 };
@@ -416,6 +432,10 @@ export const createApp = async ({
   templatesOrExtensions = [],
   installDependencies = true,
   ignorePackage = false,
+  offline,
+  cacheDir,
+  refresh,
+  refreshAfterHours,
   ...customOptions
 }: CreateAppOptions) => {
   const root = path.resolve(name);
@@ -458,6 +478,10 @@ export const createApp = async ({
     useBun,
     runCommand,
     ignorePackage,
+    ...(offline !== undefined ? { offline } : {}),
+    ...(cacheDir !== undefined ? { cacheDir } : {}),
+    ...(refresh !== undefined ? { refresh } : {}),
+    ...(refreshAfterHours !== undefined ? { refreshAfterHours } : {}),
   });
 
   fs.writeFileSync(
@@ -531,6 +555,10 @@ export const createApp = async ({
     installDependencies,
     runCommand,
     installCommand,
+    ...(offline !== undefined ? { offline } : {}),
+    ...(cacheDir !== undefined ? { cacheDir } : {}),
+    ...(refresh !== undefined ? { refresh } : {}),
+    ...(refreshAfterHours !== undefined ? { refreshAfterHours } : {}),
     ...customOptions,
   });
 };

--- a/packages/create-node-app-core/loaders.ts
+++ b/packages/create-node-app-core/loaders.ts
@@ -326,6 +326,10 @@ export type LoadFilesOptions = {
   srcDir?: string;
   runCommand: string;
   installCommand: string;
+  offline?: boolean;
+  cacheDir?: string;
+  refresh?: import("./git.js").RefreshMode;
+  refreshAfterHours?: number;
 } & {
   [key: string]: unknown;
 };
@@ -342,12 +346,21 @@ export const loadFiles = async ({
   srcDir = DEFAULT_SRC_PATH,
   runCommand,
   installCommand,
+  offline,
+  cacheDir,
+  refresh,
+  refreshAfterHours,
   ...customOptions
 }: LoadFilesOptions) => {
   try {
     const operations = [];
     for await (const { url: templateOrExtensionUrl } of templatesOrExtensions) {
-      const templateDir = await getTemplateDirPath(templateOrExtensionUrl);
+      const templateDir = await getTemplateDirPath(templateOrExtensionUrl, {
+        ...(offline !== undefined ? { offline } : {}),
+        ...(cacheDir !== undefined ? { cacheDir } : {}),
+        ...(refresh !== undefined ? { refresh } : {}),
+        ...(refreshAfterHours !== undefined ? { refreshAfterHours } : {}),
+      });
       if (verbose) {
         try {
           const stat = fs.existsSync(templateDir)

--- a/packages/create-node-app-core/package.ts
+++ b/packages/create-node-app-core/package.ts
@@ -40,6 +40,10 @@ const requireIfExists = (path: string) => {
 export type LoadPackagesOptions = {
   templatesOrExtensions?: TemplateOrExtension[];
   ignorePackage?: boolean;
+  offline?: boolean;
+  cacheDir?: string;
+  refresh?: import("./git.js").RefreshMode;
+  refreshAfterHours?: number;
   [key: string]: unknown;
 };
 
@@ -53,15 +57,31 @@ export type LoadPackagesOptions = {
 export const loadPackages = async ({
   templatesOrExtensions = [],
   ignorePackage: globalIgnorePackage = false,
+  offline,
+  cacheDir,
+  refresh,
+  refreshAfterHours,
   ...config
 }: LoadPackagesOptions) => {
+  const pathOpts = {
+    ...(offline !== undefined ? { offline } : {}),
+    ...(cacheDir !== undefined ? { cacheDir } : {}),
+    ...(refresh !== undefined ? { refresh } : {}),
+    ...(refreshAfterHours !== undefined ? { refreshAfterHours } : {}),
+  };
+
   // Load and merge template packages concurrently
   const setup = await Promise.all(
     templatesOrExtensions.map(async ({ url: templateOrExtension }) => {
       try {
         // Try to load and merge template package
         const template = requireIfExists(
-          await getPackagePath(templateOrExtension, "template.json"),
+          await getPackagePath(
+            templateOrExtension,
+            "template.json",
+            false,
+            pathOpts,
+          ),
         );
         return template.package || {}; // Use an empty object if template.json is not found
       } catch {
@@ -92,6 +112,7 @@ export const loadPackages = async ({
               templateOrExtension,
               "package.json",
               globalIgnorePackage || ignorePackage,
+              pathOpts,
             ),
           );
           return templateOrExtensionPackageJson; // Use an empty object if package.json is not found
@@ -108,7 +129,7 @@ export const loadPackages = async ({
       try {
         // Try to resolve package updates using package module
         const resolveTemplateOrExtensionPackage = requireIfExists(
-          await getPackagePath(templateOrExtension),
+          await getPackagePath(templateOrExtension, "package", false, pathOpts),
         );
         return resolveTemplateOrExtensionPackage(mergedSetup, config); // Use an empty object if resolution fails
       } catch {

--- a/packages/create-node-app-core/paths.ts
+++ b/packages/create-node-app-core/paths.ts
@@ -72,13 +72,24 @@ type SolveRepositoryPathOptions = {
   url: string;
   branch?: string;
   subdir?: string;
+  offline?: boolean;
+  cacheDir?: string;
+  refresh?: import("./git.js").RefreshMode;
+  refreshAfterHours?: number;
 };
 
 const solveRepositoryPath = async ({
   url,
   branch,
   subdir,
+  offline,
+  cacheDir,
+  refresh,
+  refreshAfterHours,
 }: SolveRepositoryPathOptions) => {
+  // targetId includes branch but not subdir, so multiple addons that share a
+  // base template (e.g. react-tailwindcss and react-shadcn) deduplicate the
+  // git cache directory.
   const targetId = Buffer.from(`${url}#${branch}`).toString("base64");
   const targetWithSubdir = Buffer.from(`${url}#${branch}#${subdir}`).toString(
     "base64",
@@ -95,6 +106,10 @@ const solveRepositoryPath = async ({
     branch: branch || "",
     target,
     targetId,
+    ...(offline !== undefined ? { offline } : {}),
+    ...(cacheDir !== undefined ? { cacheDir } : {}),
+    ...(refresh !== undefined ? { refresh } : {}),
+    ...(refreshAfterHours !== undefined ? { refreshAfterHours } : {}),
   });
 
   return { dir: target, subdir };
@@ -109,6 +124,12 @@ type SolvedTemplatePath = {
 
 const solveTemplateOrExtensionPath = async (
   templateOrExtension: string,
+  opts?: {
+    offline?: boolean;
+    cacheDir?: string;
+    refresh?: import("./git.js").RefreshMode;
+    refreshAfterHours?: number;
+  },
 ): Promise<SolvedTemplatePath> => {
   let parsed: ReturnType<typeof solveValuesFromTemplateOrExtensionUrl>;
   try {
@@ -134,7 +155,17 @@ const solveTemplateOrExtensionPath = async (
     return { dir: pathname, subdir, ignorePackage };
   }
 
-  const gitData = await solveRepositoryPath({ url, branch, subdir });
+  const gitData = await solveRepositoryPath({
+    url,
+    branch,
+    subdir,
+    ...(opts?.offline !== undefined ? { offline: opts.offline } : {}),
+    ...(opts?.cacheDir !== undefined ? { cacheDir: opts.cacheDir } : {}),
+    ...(opts?.refresh !== undefined ? { refresh: opts.refresh } : {}),
+    ...(opts?.refreshAfterHours !== undefined
+      ? { refreshAfterHours: opts.refreshAfterHours }
+      : {}),
+  });
   return { dir: gitData.dir, subdir: gitData.subdir, ignorePackage };
 };
 
@@ -142,12 +173,18 @@ export const getPackagePath = async (
   templateOrExtension: string,
   name = "package",
   ignorePackage = false,
+  opts?: {
+    offline?: boolean;
+    cacheDir?: string;
+    refresh?: import("./git.js").RefreshMode;
+    refreshAfterHours?: number;
+  },
 ) => {
   const {
     dir,
     subdir,
     ignorePackage: templateOrExtensionIgnorePackage,
-  } = await solveTemplateOrExtensionPath(templateOrExtension);
+  } = await solveTemplateOrExtensionPath(templateOrExtension, opts);
 
   if (
     name === "package.json" &&
@@ -165,6 +202,13 @@ export const getPackagePath = async (
   return path.resolve(dir, name);
 };
 
+export type GetTemplatePathOptions = {
+  offline?: boolean;
+  cacheDir?: string;
+  refresh?: import("./git.js").RefreshMode;
+  refreshAfterHours?: number;
+};
+
 /**
  * Returns the base directory for a template URL — i.e. the directory that
  * CONTAINS the optional `template/` subdirectory. This is where cna.config.json
@@ -172,10 +216,12 @@ export const getPackagePath = async (
  */
 export const getTemplateBaseDirPath = async (
   templateOrExtensionUrl: string,
+  opts?: GetTemplatePathOptions,
 ): Promise<string> => {
   try {
     const { dir, subdir = "" } = await solveTemplateOrExtensionPath(
       templateOrExtensionUrl,
+      opts,
     );
     return path.resolve(dir, subdir);
   } catch {
@@ -183,9 +229,13 @@ export const getTemplateBaseDirPath = async (
   }
 };
 
-export const getTemplateDirPath = async (templateOrExtensionUrl: string) => {
+export const getTemplateDirPath = async (
+  templateOrExtensionUrl: string,
+  opts?: GetTemplatePathOptions,
+) => {
   const { dir, subdir = "" } = await solveTemplateOrExtensionPath(
     templateOrExtensionUrl,
+    opts,
   );
   let templateDirPath = path.resolve(dir, subdir);
 

--- a/packages/create-node-app-core/tests/git.test.mts
+++ b/packages/create-node-app-core/tests/git.test.mts
@@ -1,0 +1,260 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { execFileSync } from "child_process";
+import {
+  __resetGitStateForTests,
+  downloadRepository,
+  readCacheMeta,
+  resolveCacheDir,
+  writeCacheMeta,
+  type RefreshMode,
+} from "../git.js";
+
+const makeTempDir = (): string => {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "cna-test-"));
+};
+
+const initWorkingRepo = (dir: string): void => {
+  execFileSync("git", ["init", "--initial-branch=main", dir], {
+    stdio: "ignore",
+  });
+  execFileSync("git", ["config", "user.email", "test@example.com"], {
+    cwd: dir,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["config", "user.name", "Test"], {
+    cwd: dir,
+    stdio: "ignore",
+  });
+  fs.writeFileSync(path.join(dir, "README.md"), "hello\n");
+  execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "initial"], {
+    cwd: dir,
+    stdio: "ignore",
+  });
+};
+
+/**
+ * Create a local bare git repository that can be cloned via the file://
+ * protocol. Returns the absolute path to the bare repo.
+ */
+const makeLocalBareGitRepo = (): string => {
+  const bare = makeTempDir();
+  execFileSync("git", ["init", "--bare", "--initial-branch=main", bare], {
+    stdio: "ignore",
+  });
+  // Create a working repo with one commit, push to bare, then return bare.
+  const work = makeTempDir();
+  initWorkingRepo(work);
+  execFileSync("git", ["remote", "add", "origin", bare], {
+    cwd: work,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["push", "origin", "main"], {
+    cwd: work,
+    stdio: "ignore",
+  });
+  cleanup(work);
+  return bare;
+};
+
+const cleanup = (dir: string): void => {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+};
+
+async function withTempCnaCacheDir<T>(
+  fn: (cacheRoot: string) => Promise<T> | void,
+): Promise<T | void> {
+  const dir = makeTempDir();
+  process.env.CNA_CACHE_DIR = dir;
+  try {
+    return await fn(dir);
+  } finally {
+    delete process.env.CNA_CACHE_DIR;
+    cleanup(dir);
+  }
+}
+
+test("resolveCacheDir honors CNA_CACHE_DIR", async () => {
+  await withTempCnaCacheDir((cacheRoot) => {
+    const resolved = resolveCacheDir("abc123");
+    assert.equal(resolved, path.join(cacheRoot, "abc123"));
+  });
+});
+
+test("resolveCacheDir defaults to ~/.cache/cna", () => {
+  delete process.env.CNA_CACHE_DIR;
+  const resolved = resolveCacheDir("abc123");
+  assert.equal(resolved, path.join(os.homedir(), ".cache", "cna", "abc123"));
+});
+
+test("writeCacheMeta and readCacheMeta round-trip", async () => {
+  const cacheDir = makeTempDir();
+  try {
+    writeCacheMeta(cacheDir, {
+      lastFetchedAt: "2026-01-01T00:00:00.000Z",
+      lastCommitSha: "abc1234",
+      lastRefreshReason: "clone",
+      branch: "main",
+      url: "https://github.com/foo/bar",
+    });
+    const meta = readCacheMeta(cacheDir);
+    assert.ok(meta);
+    assert.equal(meta.lastCommitSha, "abc1234");
+    assert.equal(meta.branch, "main");
+    assert.equal(meta.lastRefreshReason, "clone");
+  } finally {
+    cleanup(cacheDir);
+  }
+});
+
+test("readCacheMeta returns null when missing", () => {
+  const dir = makeTempDir();
+  try {
+    assert.equal(readCacheMeta(dir), null);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("readCacheMeta returns null on malformed JSON", () => {
+  const dir = makeTempDir();
+  try {
+    fs.writeFileSync(path.join(dir, ".cna-meta.json"), "{ not json");
+    assert.equal(readCacheMeta(dir), null);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("downloadRepository: clone writes meta sidecar and copies to target", async () => {
+  await withTempCnaCacheDir(async (cacheRoot) => {
+    __resetGitStateForTests();
+    const source = makeLocalBareGitRepo();
+    const target = makeTempDir();
+    try {
+      await downloadRepository({
+        url: source,
+        target,
+        branch: "main",
+        refresh: "always" as RefreshMode,
+      });
+      // Files copied
+      assert.ok(fs.existsSync(path.join(target, "README.md")));
+      // Meta written in the cache entry (keyed by base64 of "<source>@main")
+      const entry = resolveCacheDir(
+        Buffer.from(`${source}@main`).toString("base64"),
+        cacheRoot,
+      );
+      const meta = readCacheMeta(entry);
+      assert.ok(meta);
+      assert.equal(meta.lastRefreshReason, "clone");
+      assert.equal(meta.branch, "main");
+      assert.ok(meta.lastCommitSha);
+    } finally {
+      cleanup(source);
+      cleanup(target);
+    }
+  });
+});
+
+test("downloadRepository: offline + fresh cache skips pull (meta unchanged)", async () => {
+  await withTempCnaCacheDir(async (cacheRoot) => {
+    __resetGitStateForTests();
+    const source = makeLocalBareGitRepo();
+    const target = makeTempDir();
+    try {
+      // First run: clone
+      await downloadRepository({
+        url: source,
+        target,
+        branch: "main",
+        refresh: "always" as RefreshMode,
+      });
+      const entry = resolveCacheDir(
+        Buffer.from(`${source}@main`).toString("base64"),
+        cacheRoot,
+      );
+      const metaBefore = readCacheMeta(entry);
+      assert.ok(metaBefore);
+      const firstSha = metaBefore.lastCommitSha;
+
+      // Reset completion cache so the next call actually runs.
+      __resetGitStateForTests();
+      // Now run again with manual refresh + offline. Should NOT pull.
+      await downloadRepository({
+        url: source,
+        target: makeTempDir(),
+        branch: "main",
+        offline: true,
+        refresh: "manual" as RefreshMode,
+      });
+      const metaAfter = readCacheMeta(entry);
+      assert.ok(metaAfter);
+      // Manual + offline should preserve the original SHA and not update
+      // lastFetchedAt.
+      assert.equal(metaAfter.lastCommitSha, firstSha);
+    } finally {
+      cleanup(source);
+      cleanup(target);
+    }
+  });
+});
+
+test("downloadRepository: refresh=always forces pull on cache hit", async () => {
+  await withTempCnaCacheDir(async () => {
+    __resetGitStateForTests();
+    const source = makeLocalBareGitRepo();
+    const target = makeTempDir();
+    try {
+      await downloadRepository({
+        url: source,
+        target,
+        branch: "main",
+        refresh: "always" as RefreshMode,
+      });
+      // Push a new commit to the source.
+      const work = makeTempDir();
+      execFileSync("git", ["clone", source, work], { stdio: "ignore" });
+      execFileSync("git", ["config", "user.email", "test@example.com"], {
+        cwd: work,
+        stdio: "ignore",
+      });
+      execFileSync("git", ["config", "user.name", "Test"], {
+        cwd: work,
+        stdio: "ignore",
+      });
+      fs.writeFileSync(path.join(work, "second.txt"), "two\n");
+      execFileSync("git", ["add", "."], { cwd: work, stdio: "ignore" });
+      execFileSync("git", ["commit", "-m", "second"], {
+        cwd: work,
+        stdio: "ignore",
+      });
+      execFileSync("git", ["push", "origin", "main"], {
+        cwd: work,
+        stdio: "ignore",
+      });
+      cleanup(work);
+
+      const newTarget = makeTempDir();
+      __resetGitStateForTests();
+      await downloadRepository({
+        url: source,
+        target: newTarget,
+        branch: "main",
+        refresh: "always" as RefreshMode,
+      });
+      assert.ok(fs.existsSync(path.join(newTarget, "second.txt")));
+    } finally {
+      cleanup(source);
+      cleanup(target);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements sub-issue [#180](https://github.com/Create-Node-App/create-node-app/issues/180) — the cache + smart refresh work from epic [#179](https://github.com/Create-Node-App/create-node-app/issues/179). This is the foundation that sub-issues #181 (observability), #185 (concurrency), and #186 (reproducibility) build on.

## New CLI flags

| Flag | Description |
|---|---|
| `--offline` | Use the local cache only; do not refresh templates from the network |
| `--no-cache` | Disable the catalog cache; force a refresh on every run |
| `--cache-dir <path>` | Override the cache root (default: `~/.cache/cna`; also `CNA_CACHE_DIR`) |
| `--refresh <mode>` | When to refresh: `always` \| `stale` \| `manual` (default: `stale`) |

## New `cna cache` subcommand

```bash
cna cache dir          # print the cache root
cna cache list         # list cached templates/extensions
cna cache clean [id]   # remove one or all entries; pass --catalog to also clear the catalog cache
cna cache verify [id]  # run git fsck on one or all entries
```

## Cache layout improvements

- **Per-entry `.cna-meta.json` sidecar** with `lastFetchedAt`, `lastCommitSha`, `lastRefreshReason`, `branch`, `url`.
- **Default refresh mode changed from `always` to `stale`** (only pulls if cache is older than `CNA_REFRESH_AFTER_HOURS`, default 24h). The previous behavior of an unconditional `git pull` on every run was a major perf and offline-fragility footgun.
- **Working-copy prep now uses `cp -c` (reflink) / `cp -l` (hardlink) with a recursive copy fallback.** A warm scaffold is O(1) on the working dir when reflinks are available.
- **Template catalog persisted to disk** at `~/.cache/cna/catalog/templates.json` and used as a fallback when the network is unavailable.

## Network and dependency hygiene

- **Dropped the `axios` dependency.** The template catalog now uses the global `fetch` with a 10 s `AbortSignal.timeout()` and a `User-Agent: create-awesome-node-app/<version>` header. ~90 kB smaller bundle, real timeouts, no more `hangs indefinitely` on slow networks.

## Tests

- **`packages/create-node-app-core/tests/git.test.mts`** (new, 8 cases): `resolveCacheDir` honors `CNA_CACHE_DIR`; `writeCacheMeta`/`readCacheMeta` round-trip; malformed JSON handling; `downloadRepository` writes the meta sidecar on clone; `offline` + fresh cache skips the pull; `refresh=always` forces a pull.
- **`packages/create-awesome-node-app/tests/cache.test.mts`** (new, 9 cases): `listCacheEntries` skips the catalog subdir; `cleanCache` with and without an id; `verifyCache` runs `git fsck`; catalog on-disk persistence.
- **`packages/create-awesome-node-app/tests/templates-fetch.test.mts`** (new, 5 cases): fetch + cache + persist; disk fallback on HTTP 500; error on total network failure.

All 28 CLI tests + 30 core tests pass. Lint, type-check, and build are green.

## Files changed

- `packages/create-awesome-node-app/src/templates.ts` — drop axios, use fetch with timeout/UA, disk catalog fallback
- `packages/create-awesome-node-app/src/cache.ts` *(new)* — cache inspection, clean, verify
- `packages/create-awesome-node-app/src/cache-cli.ts` *(new)* — `cna cache` subcommand implementation
- `packages/create-awesome-node-app/src/index.ts` — new flags, cache subcommand wiring
- `packages/create-node-app-core/git.ts` — smart refresh, meta sidecar, reflink/hardlink copy
- `packages/create-node-app-core/paths.ts` — `offline` / `cacheDir` / `refresh` plumbing
- `packages/create-node-app-core/loaders.ts`, `package.ts`, `installer.ts`, `index.ts` — thread the new options through
- `packages/create-awesome-node-app/package.json` — drop `axios`
- `packages/create-awesome-node-app/README.md`, `docs/TROUBLESHOOTING.md` — usage docs
- `.changeset/cache-controls-and-smart-refresh.md` *(new)* — minor bump changeset

## Related

- Closes #180
- Parent: #179
- Followed by: #181, #185, #186 (all block on this)

## Test plan

```bash
# In the repo
npm run build && npm run lint && npm run type-check && CNA_SKIP_GIT=1 npm run test
```

The smoke test (which performs a real network clone) is excluded via `CNA_SKIP_GIT=1` for the unit-test run. It runs separately in the `cross-platform-scaffold` job on `windows-latest` and `macos-latest`, and the `bun-scaffold` job on `ubuntu-latest` — neither of which were changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cache controls for scaffolding, including offline use, custom cache location, cache refresh modes, and a new cache management command.
  * Improved template loading so projects can continue working when the network is unavailable.
  * Added faster local file copying to reduce setup time in supported environments.

* **Bug Fixes**
  * Made template fetching more reliable with timeouts and automatic fallback to cached data.
  * Fixed cache handling so stale or broken entries can be cleaned and verified more easily.

* **Documentation**
  * Expanded troubleshooting and CLI reference docs for cache behavior and offline workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->