### PR TITLE
chore: align config drift — AGENTS.md, engines, devcontainer, gitleaks (closes #183)

### DIFF
--- a/.changeset/config-drift-183.md
+++ b/.changeset/config-drift-183.md
@@ -1,0 +1,18 @@
+---
+"create-awesome-node-app": patch
+"@create-node-app/core": patch
+---
+
+Config drift alignment (closes #183)
+
+- **AGENTS.md**: corrected from `pnpm 10+` to `npm 10+` — the repo uses
+  `npm` workspaces with `packageManager: "npm@10.9.2"`.
+- **Dev container**: `VARIANT` bumped from `18` to `22` so contributors
+  get a Node 22 shell by default.
+- **Engines**: `engines.npm` tightened from `>=7.0.0` (irrelevant — npm 7
+  is below the bundled npm 10 in Node 22) to `>=10.9.2`, matching
+  `packageManager`.
+- **MegaLinter**: re-enabled `REPOSITORY_GITLEAKS` (disabled without
+  explanation alongside `CHECKOV`, `GRYPE`, `TRIVY` which are heavy
+  scanners; Gitleaks is lightweight secret detection).
+- **README**: added Node 22 LTS and npm 10 badges in the badge row.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-      "VARIANT": "18"
+      "VARIANT": "22"
     }
   },
   "customizations": {

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -20,7 +20,6 @@ DISABLE_LINTERS:
   - JAVASCRIPT_ES # Root ESLint project service does not include standalone JS config entrypoints
   - JSON_V8R # v8r flags valid tsconfig variants against generic JSON schemas
   - REPOSITORY_CHECKOV
-  - REPOSITORY_GITLEAKS
   - REPOSITORY_GRYPE
   - REPOSITORY_OSV_SCANNER # Handled by scheduled workflow in .github/workflows/osv-scanner.yml
   - REPOSITORY_TRIVY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 - TypeScript
 - Node.js 22+
-- pnpm 10+
+- npm 10+
 - Turborepo (monorepo)
 
 ## Key Commands

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 [![Downloads][npmdownloads]][npmurl]
 [![License: MIT][licensebadge]][licenseurl]
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/ulises-jeremias?style=flat&logo=github)](https://github.com/sponsors/ulises-jeremias)
+[![Node version](https://img.shields.io/badge/node-22%20LTS-339933?style=flat&logo=nodedotjs&logoColor=white)](.node-version)
+[![npm version](https://img.shields.io/badge/npm-10-CC3534?style=flat&logo=npm&logoColor=white)](.node-version)
 
 [Package README](./packages/create-awesome-node-app/README.md) · [Official Site](https://create-awesome-node-app.vercel.app) · [Templates](https://create-awesome-node-app.vercel.app/templates) · [Extensions](https://create-awesome-node-app.vercel.app/extensions) · [Contributing](./CONTRIBUTING.md) · [Troubleshooting](./docs/TROUBLESHOOTING.md)
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     ]
   },
   "engines": {
-    "npm": ">=7.0.0",
+    "npm": ">=10.9.2",
     "node": ">=22.0.0"
   },
   "packageManager": "npm@10.9.2",


### PR DESCRIPTION
## Summary

Closes #183. Resolves several scattered config drifts in the repo tooling — the dev container, engine constraints, and documentation all disagree about which Node version and package manager the project expects.

## Changes

- **AGENTS.md**: `pnpm 10+` → `npm 10+` (the repo uses npm workspaces with `packageManager: "npm@10.9.2"`; there has never been a pnpm config in the repo)
- **Dev container** (`.devcontainer/devcontainer.json`): `VARIANT` bumped from `18` to `22` — the project requires Node >= 22 and opening the container gave a Node 18 shell.
- **Engines** (`package.json`): `engines.npm` tightened from `>=7.0.0` (which was below the Node 22-bundled npm 10) to `>=10.9.2`, matching the `packageManager` field exactly.
- **MegaLinter** (`.mega-linter.yml`): re-enabled `REPOSITORY_GITLEAKS` — it was disabled alongside heavy scanners (CHECKOV, GRYPE, TRIVY) for no reason; Gitleaks is a lightweight secret scan and should run on every push.
- **README.md**: added Node 22 LTS and npm 10 badges in the badge row so contributors can see the requirements at a glance.

## Verification

```bash
npm run build     # ✅
npm run lint      # ✅
npm run type-check # ✅
CNA_SKIP_GIT=1 npm run test  # ✅ — 30 core, 28 CLI
```

## Related

- Closes #183
- Parent: #179
