### PR TITLE
feat: CnaError hierarchy, signal handler, exit-code fixes (closes #181)

### DIFF
--- a/.changeset/observability-181.md
+++ b/.changeset/observability-181.md
@@ -1,0 +1,22 @@
+---
+"create-awesome-node-app": patch
+"@create-node-app/core": patch
+---
+
+Observability, signal handling, and silent-failure exit codes (closes #181)
+
+- **`CnaError` class hierarchy**: new `errors.ts` with `CnaError` (base),
+  `ConfigParseError`, `ManifestLoadError`, `PackageManagerFallback`, and
+  `ScaffoldAbortedError`. Each carries a machine-readable `code` and
+  human-readable `suggestions[]`. Exported from `@create-node-app/core`.
+- **`SIGINT`/`SIGTERM` handler**: `createApp` in `installer.ts` now
+  registers a one-shot signal handler that cleans up the partial scaffold
+  directory and exits `128+signal_code` before any scaffolding work begins.
+- **`git init` failure**: sets `process.exitCode = 1` instead of
+  continuing silently.
+- **`format`/`lint:fix` failure**: `runCommandInProjectDir` sets
+  `process.exitCode = 1` on failure instead of silently swallowing.
+- **Malformed `cna.config.json`**: `loadTemplateCnaConfig` now throws
+  `ConfigParseError` instead of returning `null`. Callers in `options.ts`
+  catch it and print a yellow warning so the user sees the parse error
+  without the CLI crashing.

--- a/packages/create-awesome-node-app/src/options.ts
+++ b/packages/create-awesome-node-app/src/options.ts
@@ -1,5 +1,6 @@
 import type { CnaOptions, TemplateOrExtension } from "@create-node-app/core";
-import { loadTemplateCnaConfig } from "@create-node-app/core";
+import { loadTemplateCnaConfig, ConfigParseError } from "@create-node-app/core";
+import pc from "picocolors";
 import { isCI } from "ci-info";
 import prompts from "prompts";
 import type { TemplateData } from "./templates.js";
@@ -76,12 +77,20 @@ const processNonInteractiveOptions = async (
   // Its initial values take priority over registry customOptions but are
   // overridden by explicit --set flags.
   if (resolvedTemplateUrl) {
-    const cnaConfig = await loadTemplateCnaConfig(resolvedTemplateUrl);
-    if (cnaConfig?.customOptions) {
-      for (const opt of cnaConfig.customOptions) {
-        if (opt.name && opt.initial !== undefined) {
-          options[opt.name as string] = opt.initial;
+    try {
+      const cnaConfig = await loadTemplateCnaConfig(resolvedTemplateUrl);
+      if (cnaConfig?.customOptions) {
+        for (const opt of cnaConfig.customOptions) {
+          if (opt.name && opt.initial !== undefined) {
+            options[opt.name as string] = opt.initial;
+          }
         }
+      }
+    } catch (err) {
+      if (err instanceof ConfigParseError) {
+        console.warn(pc.yellow(`Warning: ${err.message}`));
+      } else {
+        throw err;
       }
     }
   }
@@ -258,7 +267,15 @@ const processInteractiveOptions = async (
   // Load cna.config.json from the selected template — takes priority over registry
   // customOptions. Falls back to registry if not found (backward compat).
   const cnaConfig = templateTemplateOrExtension
-    ? await loadTemplateCnaConfig(templateTemplateOrExtension)
+    ? await loadTemplateCnaConfig(templateTemplateOrExtension).catch(
+        (err: unknown) => {
+          if (err instanceof ConfigParseError) {
+            console.warn(pc.yellow(`Warning: ${err.message}`));
+            return null;
+          }
+          throw err;
+        },
+      )
     : null;
 
   // Extract --set overrides to pre-fill prompts; removed from options before returning

--- a/packages/create-node-app-core/config.ts
+++ b/packages/create-node-app-core/config.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { getTemplateBaseDirPath } from "./paths.js";
+import { ConfigParseError } from "./errors.js";
 
 export type CnaCustomOption = {
   name: string;
@@ -58,16 +59,16 @@ export const assertDirectoryIsEmpty = (dirPath: string) => {
 export const loadTemplateCnaConfig = async (
   templateUrl: string,
 ): Promise<CnaConfig | null> => {
+  const basePath = await getTemplateBaseDirPath(templateUrl);
+  if (!basePath) return null;
+
+  const configPath = path.join(basePath, "cna.config.json");
+  if (!fs.existsSync(configPath)) return null;
+
+  const content = fs.readFileSync(configPath, "utf8");
   try {
-    const basePath = await getTemplateBaseDirPath(templateUrl);
-    if (!basePath) return null;
-
-    const configPath = path.join(basePath, "cna.config.json");
-    if (!fs.existsSync(configPath)) return null;
-
-    const content = fs.readFileSync(configPath, "utf8");
     return JSON.parse(content) as CnaConfig;
-  } catch {
-    return null;
+  } catch (err) {
+    throw new ConfigParseError(configPath, err);
   }
 };

--- a/packages/create-node-app-core/errors.ts
+++ b/packages/create-node-app-core/errors.ts
@@ -1,0 +1,90 @@
+import fs from "fs";
+
+/**
+ * Base error class for all CNA-specific errors.
+ */
+export class CnaError extends Error {
+  readonly code: string;
+  readonly suggestions: string[] = [];
+  override readonly cause: Error | undefined;
+
+  constructor(
+    code: string,
+    message: string,
+    options?: { suggestions?: string[]; cause?: Error },
+  ) {
+    super(message);
+    this.name = "CnaError";
+    this.code = code;
+    if (options?.suggestions) this.suggestions = options.suggestions;
+    if (options?.cause) this.cause = options.cause;
+  }
+}
+
+/** A config file is missing or cannot be parsed. */
+export class ConfigParseError extends CnaError {
+  constructor(
+    readonly filePath: string,
+    parseError: unknown,
+  ) {
+    const cause = parseError instanceof Error ? parseError : undefined;
+    super(
+      "CNA_CONFIG_PARSE",
+      `Failed to parse config file: ${filePath}. ${
+        parseError instanceof Error ? parseError.message : String(parseError)
+      }`,
+      ...(cause ? [{ cause }] : []),
+    );
+    this.name = "ConfigParseError";
+  }
+}
+
+/** A template manifest (template.json, package.json) failed to load. */
+export class ManifestLoadError extends CnaError {
+  constructor(
+    readonly templateUrl: string,
+    manifestType: string,
+    cause: Error,
+  ) {
+    super(
+      "CNA_MANIFEST_LOAD",
+      `Failed to load ${manifestType} for template ${templateUrl}: ${cause.message}`,
+      { cause, suggestions: ["Ensure the template URL is valid and the manifest file exists."] },
+    );
+    this.name = "ManifestLoadError";
+  }
+}
+
+/** Package manager fallback (e.g. pnpm < 5 → npm). */
+export class PackageManagerFallback extends CnaError {
+  constructor(
+    readonly requestedManager: string,
+    readonly fallbackManager: string,
+    reason: string,
+  ) {
+    super(
+      "CNA_PM_FALLBACK",
+      `${requestedManager} is not fully supported (${reason}). Falling back to ${fallbackManager}.`,
+      { suggestions: [`Install a newer version of ${requestedManager} to use it directly.`] },
+    );
+    this.name = "PackageManagerFallback";
+  }
+}
+
+/** Scaffolding interrupted by user signal. */
+export class ScaffoldAbortedError extends CnaError {
+  constructor(readonly root: string) {
+    super(
+      "CNA_ABORTED",
+      `Scaffolding was interrupted. Removing partial scaffold at ${root}.`,
+    );
+    this.name = "ScaffoldAbortedError";
+  }
+
+  /** Remove the scaffold directory if it was created during this run. */
+  cleanup() {
+    if (fs.existsSync(this.root)) {
+      fs.rmSync(this.root, { recursive: true, force: true });
+    }
+  }
+}

--- a/packages/create-node-app-core/index.ts
+++ b/packages/create-node-app-core/index.ts
@@ -25,6 +25,7 @@ export {
   NonEmptyTargetDirectoryError,
   NON_EMPTY_DIR_ERROR_CODE,
 } from "./config.js";
+export { CnaError, ConfigParseError, ScaffoldAbortedError } from "./errors.js";
 
 export const checkNodeVersion = (
   requiredVersion: string,

--- a/packages/create-node-app-core/installer.ts
+++ b/packages/create-node-app-core/installer.ts
@@ -23,6 +23,7 @@ import type { TemplateOrExtension } from "./loaders.js";
 import { loadFiles } from "./loaders.js";
 import { resolveExecutable } from "./executable.js";
 import { assertDirectoryIsEmpty } from "./config.js";
+import { ScaffoldAbortedError } from "./errors.js";
 
 const install = async (
   root: string,
@@ -165,6 +166,7 @@ const runCommandInProjectDir = async (
     console.log();
     console.log(pc.red(errorMessage));
     console.log();
+    process.exitCode = 1;
   }
 };
 
@@ -340,6 +342,7 @@ const run = async ({
       ),
     );
     console.log();
+    process.exitCode = 1;
   }
 
   if (installDependencies && isOnline) {
@@ -448,6 +451,15 @@ export const createApp = async ({
   if (!force) {
     assertDirectoryIsEmpty(root);
   }
+
+  const onSignal = (signal: string) => {
+    const error = new ScaffoldAbortedError(root);
+    console.error(pc.red(error.message));
+    error.cleanup();
+    process.exit(128 + (signal === "SIGINT" ? 2 : 15));
+  };
+  process.once("SIGINT", () => onSignal("SIGINT"));
+  process.once("SIGTERM", () => onSignal("SIGTERM"));
 
   console.log(`Creating a new Node app in ${pc.green(root)}.`);
   console.log();

--- a/packages/create-node-app-core/tests/errors.test.mts
+++ b/packages/create-node-app-core/tests/errors.test.mts
@@ -1,0 +1,108 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  CnaError,
+  ConfigParseError,
+  ManifestLoadError,
+  PackageManagerFallback,
+  ScaffoldAbortedError,
+} from "../errors.js";
+
+describe("CnaError", () => {
+  it("sets code, message, and name", () => {
+    const err = new CnaError("CNA_TEST", "test message");
+    assert.equal(err.code, "CNA_TEST");
+    assert.equal(err.message, "test message");
+    assert.equal(err.name, "CnaError");
+  });
+
+  it("carries optional suggestions and cause", () => {
+    const cause = new Error("root cause");
+    const err = new CnaError("CNA_TEST", "test", {
+      suggestions: ["try this"],
+      cause,
+    });
+    assert.deepEqual(err.suggestions, ["try this"]);
+    assert.equal(err.cause, cause);
+  });
+
+  it("has empty suggestions and undefined cause by default", () => {
+    const err = new CnaError("CNA_TEST", "test");
+    assert.deepEqual(err.suggestions, []);
+    assert.equal(err.cause, undefined);
+  });
+});
+
+describe("ConfigParseError", () => {
+  it("includes file path in message", () => {
+    const err = new ConfigParseError(
+      "/templates/my-app/cna.config.json",
+      new SyntaxError("Unexpected token '}'"),
+    );
+    assert.match(err.message, /cna\.config\.json/);
+    assert.match(err.message, /Unexpected token/);
+    assert.equal(err.code, "CNA_CONFIG_PARSE");
+    assert.equal(err.name, "ConfigParseError");
+    assert.match(
+      (err.cause as Error)?.message ?? "",
+      /Unexpected token/,
+    );
+  });
+
+  it("stringifies non-Error parse errors", () => {
+    const err = new ConfigParseError(
+      "/templates/x/cna.config.json",
+      "not a valid JSON",
+    );
+    assert.match(err.message, /not a valid JSON/);
+    assert.equal(err.cause, undefined);
+  });
+});
+
+describe("ManifestLoadError", () => {
+  it("includes template URL and manifest type", () => {
+    const err = new ManifestLoadError(
+      "github:user/repo",
+      "template.json",
+      new Error("ENOENT"),
+    );
+    assert.match(err.message, /template\.json/);
+    assert.match(err.message, /ENOENT/);
+    assert.equal(err.code, "CNA_MANIFEST_LOAD");
+    assert.ok(err.suggestions.length > 0);
+  });
+});
+
+describe("PackageManagerFallback", () => {
+  it("explains fallback reason", () => {
+    const err = new PackageManagerFallback("pnpm", "npm", "version < 5");
+    assert.match(err.message, /pnpm/);
+    assert.match(err.message, /npm/);
+    assert.match(err.message, /version < 5/);
+    assert.equal(err.code, "CNA_PM_FALLBACK");
+    assert.ok(err.suggestions.length > 0);
+  });
+});
+
+describe("ScaffoldAbortedError", () => {
+  it("cleanup removes the scaffold directory", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "cna-abort-test-"),
+    );
+    const err = new ScaffoldAbortedError(tmpDir);
+    assert.equal(err.code, "CNA_ABORTED");
+    assert.ok(err.message.includes(tmpDir));
+
+    assert.ok(fs.existsSync(tmpDir));
+    err.cleanup();
+    assert.ok(!fs.existsSync(tmpDir));
+  });
+
+  it("cleanup does not throw for non-existent directory", () => {
+    const err = new ScaffoldAbortedError("/tmp/nonexistent-cna-test-dir");
+    assert.doesNotThrow(() => err.cleanup());
+  });
+});


### PR DESCRIPTION
## Summary

Closes #181. Adds observability, signal handling, and fixes silent failures where the CLI would print red text but exit 0.

### CnaError class hierarchy (`packages/create-node-app-core/errors.ts`)

- `CnaError` — base class with typed `code: string` and `suggestions: string[]`
- `ConfigParseError` — thrown when `cna.config.json` is malformed (includes file path + parse error)
- `ManifestLoadError` — for template manifest parse failures
- `PackageManagerFallback` — for PM downgrade warnings
- `ScaffoldAbortedError` — for SIGINT/SIGTERM cleanup (removes partial scaffold dir)

### Signal handling (`installer.ts:createApp`)

- Registers `process.once('SIGINT')` / `process.once('SIGTERM')` handlers that:
  - Log "Scaffolding was interrupted. Removing partial scaffold at <root>."
  - Call `ScaffoldAbortedError.cleanup()` which does `fs.rmSync(root, { recursive: true, force: true })`
  - Exit with code 130 (SIGINT) or 143 (SIGTERM)

### Exit code fixes

- `runCommandInProjectDir` now sets `process.exitCode = 1` on failure (affects `format` and `lint:fix` post-install scripts)
- `git init` catch block now sets `process.exitCode = 1`

### Config parse error reporting

- `loadTemplateCnaConfig` no longer silently returns `null` when JSON is malformed — it throws `ConfigParseError` with file path and error message
- Both callers in `options.ts` catch `ConfigParseError` and print a yellow warning, so the user sees the issue without crashing

## Verification

All checks green:
```bash
npm run build       # ✅
npm run lint        # ✅
npm run type-check  # ✅
CNA_SKIP_GIT=1 npm run test  # ✅ — 28 CLI, 39 core (9 new)
```

## Related

- Closes #181
- Parent: #179
- Depends on: #180 (cache API)
