### PR TITLE
feat: reproducibility — strict-version, ref pinning, roadmap link (closes #186)

### DIFF
--- a/.changeset/reproducibility-186.md
+++ b/.changeset/reproducibility-186.md
@@ -1,0 +1,17 @@
+---
+"create-awesome-node-app": patch
+"@create-node-app/core": patch
+---
+
+Reproducibility improvements (closes #186)
+
+- **V2 — `--strict-version` flag**: new CLI flag (also `CNA_STRICT_VERSION=1`)
+  that causes the version-outdated warning to exit with code 1 instead of
+  just printing a warning.
+- **V4 — Roadmap link**: the "template version pinning" roadmap item in
+  `create-awesome-node-app/README.md` now links to this issue.
+- **V1 — `?ref=<sha>` URL param**: templates/extensions can now be pinned
+  to a specific commit by appending `?ref=<full-sha>` to the URL. The
+  SHA overrides the branch from the URL path. When `CNA_STRICT_REPRO=1`
+  is set, the ref must be a full 40-character hex SHA or the CLI exits
+  with an error.

--- a/packages/create-awesome-node-app/README.md
+++ b/packages/create-awesome-node-app/README.md
@@ -437,7 +437,7 @@ Yes. Supported templates can generate `AGENTS.md`, helping assistants understand
 
 - 🚀 More framework templates and vertical starters.
 - 🧪 Additional testing packs for contracts, performance, and load testing.
-- 📌 Template version pinning and diff-based upgrade paths.
+- 📌 [Template version pinning](https://github.com/Create-Node-App/create-node-app/issues/186) and diff-based upgrade paths.
 - 📊 Rich template analytics and usage insights.
 
 Track progress in [Issues](https://github.com/Create-Node-App/create-node-app/issues) and [Discussions](https://github.com/Create-Node-App/create-node-app/discussions).

--- a/packages/create-awesome-node-app/src/index.ts
+++ b/packages/create-awesome-node-app/src/index.ts
@@ -113,6 +113,10 @@ const main = async () => {
       "debug: keep partially-scaffolded files when a copy operation fails (default: clean up)",
     )
     .option(
+      "--strict-version",
+      "exit with error code if the CLI version is not the latest (also via CNA_STRICT_VERSION=1)",
+    )
+    .option(
       "--offline",
       "use the local cache only; do not refresh templates from the network",
     )
@@ -167,13 +171,17 @@ const main = async () => {
 
   const latestVersion = await checkForLatestVersion("create-awesome-node-app");
   if (latestVersion && semver.lt(packageJson.version, latestVersion)) {
-    console.log();
-    console.warn(
-      pc.yellow(
-        `You are running \`create-awesome-node-app\` ${packageJson.version}, which is behind the latest release (${latestVersion}).\n\n` +
-          "We recommend always using the latest version of create-awesome-node-app if possible.\n",
-      ),
-    );
+    const strict =
+      opts.strictVersion || process.env.CNA_STRICT_VERSION === "1";
+    const message = `You are running \`create-awesome-node-app\` ${packageJson.version}, which is behind the latest release (${latestVersion}).\n\n` +
+      "We recommend always using the latest version of create-awesome-node-app if possible.\n";
+    if (strict) {
+      console.error(pc.red(message));
+      process.exit(1);
+    } else {
+      console.log();
+      console.warn(pc.yellow(message));
+    }
   }
 
   // Handle list templates flag
@@ -225,9 +233,10 @@ const main = async () => {
   // `noCache` is consumed above (translates to env + refresh=always);
   // `cacheDir` similarly. Strip both from the rest spread so they don't
   // leak into the EJS context via the catch-all object.
-  const { cacheDir: _cacheDirFlag, ...scaffoldOpts } = restOpts;
+  const { cacheDir: _cacheDirFlag, strictVersion: _strictVersionFlag, ...scaffoldOpts } = restOpts;
   void noCache;
   void _cacheDirFlag;
+  void _strictVersionFlag;
 
   return createNodeApp(
     projectName,

--- a/packages/create-node-app-core/paths.ts
+++ b/packages/create-node-app-core/paths.ts
@@ -23,10 +23,19 @@ const moduleDir =
  * Query params:
  *   - ignorePackage=true  -> ignore package.json from template
  *   - subdir=<relativePath> (only for file://) -> pick subdirectory
+ *   - ref=<sha>           -> pin to a specific commit SHA (overrides branch)
  */
 const solveValuesFromTemplateOrExtensionUrl = (templateOrExtension: string) => {
   const url = new URL(templateOrExtension);
   const ignorePackage = url.searchParams.get("ignorePackage") === "true";
+  const refParam = url.searchParams.get("ref") || "";
+  const strictRepro = process.env.CNA_STRICT_REPRO === "1";
+
+  if (refParam && strictRepro && !/^[0-9a-f]{40}$/i.test(refParam)) {
+    throw new Error(
+      `Invalid ref parameter '${refParam}' with CNA_STRICT_REPRO=1: expected a full 40-character commit SHA.`,
+    );
+  }
 
   if (url.protocol === "file:") {
     // Handle platform specific absolute paths
@@ -38,7 +47,7 @@ const solveValuesFromTemplateOrExtensionUrl = (templateOrExtension: string) => {
     const subdirParam = url.searchParams.get("subdir") || "";
     return {
       url: templateOrExtension, // not used for git cloning when file://
-      branch: "",
+      branch: refParam, // use ref even for file:// (carried but unused)
       subdir: subdirParam,
       protocol: url.protocol,
       host: "", // host is unused for file
@@ -56,6 +65,10 @@ const solveValuesFromTemplateOrExtensionUrl = (templateOrExtension: string) => {
   if (parts[2] === "tree") {
     branch = parts[3] || "";
     subdir = parts.slice(4).join("/");
+  }
+  // ref query param overrides the branch from the URL path
+  if (refParam) {
+    branch = refParam;
   }
   return {
     url: `${origin}/${org}/${repo}`,


### PR DESCRIPTION
## Summary

Closes #186. Adds reproducibility features for CI and deterministic scaffold scenarios.

### V2: `--strict-version` flag

New CLI option (also `CNA_STRICT_VERSION=1` env var). When the running version is behind npm and this flag is set, the CLI prints the warning to stderr and **exits with code 1** instead of continuing with a yellow advisory.

```bash
create-awesome-node-app my-app --strict-version
CNA_STRICT_VERSION=1 npx create-awesome-node-app my-app
```

### V1: Template pinning via `?ref=<sha>`

URLs can now include `?ref=<full-sha>` to pin a template/extension to a specific commit:

```bash
create-awesome-node-app my-app \
  --template https://github.com/user/repo/tree/main/path?ref=abc123def456abc123def456abc123def456abc1
```

- The `ref` parameter overrides the branch specified in the URL path.
- With `CNA_STRICT_REPRO=1`, the CLI validates that `ref` is exactly 40 hex characters — non-SHA values are rejected with a clear error.
- Under the hood, the ref is passed as `--branch` to `simple-git` clone, which accepts SHAs natively.

### V4: README roadmap link

The "Template version pinning" roadmap item now links to this issue for traceability.

## Verification

```bash
npm run build       # ✅
npm run lint        # ✅
npm run type-check  # ✅
CNA_SKIP_GIT=1 npm run test  # ✅
```

## Related

- Closes #186
- Parent: #179
