### PR TITLE
test: core coverage — config, extractNameAndVersion (closes #187)

### DIFF
--- a/.changeset/tests-187.md
+++ b/.changeset/tests-187.md
@@ -1,0 +1,13 @@
+---
+"@create-node-app/core": patch
+---
+
+Test coverage for core package (closes #187)
+
+- **T5**: new `config.test.mts` — `loadTemplateCnaConfig` tests for valid
+  config, missing config (returns `null`), and non-existent template URL.
+- **T8**: new `installer.test.mts` — `extractNameAndVersion` tests covering
+  simple packages, scoped packages, packages without versions, and the
+  known edge case where `@scope/package` is parsed incorrectly (scope `@` is taken
+  as the version separator).
+- Exported `extractNameAndVersion` from `installer.ts` for testability.

--- a/packages/create-node-app-core/installer.ts
+++ b/packages/create-node-app-core/installer.ts
@@ -170,7 +170,7 @@ const runCommandInProjectDir = async (
   }
 };
 
-function extractNameAndVersion(dependencyString: string) {
+export function extractNameAndVersion(dependencyString: string) {
   // extract the name and version from the dependency string separated by @
   // e.g. @types/react@^16
   // => name: @types/react

--- a/packages/create-node-app-core/tests/config.test.mts
+++ b/packages/create-node-app-core/tests/config.test.mts
@@ -1,0 +1,53 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { loadTemplateCnaConfig, NON_EMPTY_DIR_ERROR_CODE } from "../index.js";
+
+describe("loadTemplateCnaConfig", () => {
+  it("returns null for non-existent template URL", async () => {
+    const result = await loadTemplateCnaConfig(
+      "file:///tmp/nonexistent-cna-config-test",
+    );
+    assert.equal(result, null);
+  });
+
+  it("returns parsed config for a valid cna.config.json", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cna-config-valid-"));
+    try {
+      const config = { customOptions: [{ name: "projectName", type: "text", initial: "my-app" }] };
+      fs.writeFileSync(
+        path.join(tmpDir, "cna.config.json"),
+        JSON.stringify(config),
+      );
+      const result = await loadTemplateCnaConfig(
+        `file://${tmpDir}`,
+      );
+      assert.notEqual(result, null);
+      assert.deepEqual(result?.customOptions, config.customOptions);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null when cna.config.json does not exist", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cna-config-missing-"));
+    try {
+      // Create the directory but no config file
+      const result = await loadTemplateCnaConfig(
+        `file://${tmpDir}`,
+      );
+      assert.equal(result, null);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("NON_EMPTY_DIR_ERROR_CODE", () => {
+  it("is a string constant", () => {
+    assert.equal(typeof NON_EMPTY_DIR_ERROR_CODE, "string");
+    assert.ok(NON_EMPTY_DIR_ERROR_CODE.length > 0);
+  });
+});

--- a/packages/create-node-app-core/tests/installer.test.mts
+++ b/packages/create-node-app-core/tests/installer.test.mts
@@ -1,0 +1,42 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { extractNameAndVersion } from "../installer.js";
+
+describe("extractNameAndVersion", () => {
+  it("splits simple package with version", () => {
+    const result = extractNameAndVersion("react@^16.8.0");
+    assert.equal(result.name, "react");
+    assert.equal(result.version, "^16.8.0");
+  });
+
+  it("splits scoped package with version", () => {
+    const result = extractNameAndVersion("@types/react@^16");
+    assert.equal(result.name, "@types/react");
+    assert.equal(result.version, "^16");
+  });
+
+  it("returns empty version when no @ present", () => {
+    const result = extractNameAndVersion("express");
+    assert.equal(result.name, "express");
+    assert.equal(result.version, "");
+  });
+
+  it("handles package with exact version", () => {
+    const result = extractNameAndVersion("lodash@4.17.21");
+    assert.equal(result.name, "lodash");
+    assert.equal(result.version, "4.17.21");
+  });
+
+  it("handles package with tilde version", () => {
+    const result = extractNameAndVersion("chalk@~5.0.0");
+    assert.equal(result.name, "chalk");
+    assert.equal(result.version, "~5.0.0");
+  });
+
+  it("scoped package without version returns empty name (edge case)", () => {
+    const result = extractNameAndVersion("@scope/package");
+    // lastIndexOf('@') finds the scope @, not a version separator
+    assert.equal(result.name, "");
+    assert.equal(result.version, "scope/package");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #187. Adds unit test coverage for the core package.

### T5: `config.test.mts` (new, 4 tests)

Tests `loadTemplateCnaConfig`:
- Returns `null` for a non-existent template URL (no directory)
- Returns parsed config from a valid `cna.config.json`
- Returns `null` when the template directory exists but `cna.config.json` is absent
- Validates `NON_EMPTY_DIR_ERROR_CODE` constant

### T8: `installer.test.mts` (new, 6 tests)

Tests `extractNameAndVersion` (exported from `installer.ts` for testability):
- `react@^16.8.0` → `{ name: "react", version: "^16.8.0" }`
- `@types/react@^16` → `{ name: "@types/react", version: "^16" }`
- `express` (no version) → `{ name: "express", version: "" }`
- `lodash@4.17.21` (exact) → `{ name: "lodash", version: "4.17.21" }`
- `chalk@~5.0.0` (tilde) → `{ name: "chalk", version: "~5.0.0" }`
- `@scope/package` edge case documented: `lastIndexOf('@')` finds the scope separator, resulting in `{ name: "", version: "scope/package" }` — flagged in the issue for future improvement

## Verification

```bash
npm run build       # ✅
npm run lint        # ✅
npm run type-check  # ✅
CNA_SKIP_GIT=1 npm run test  # ✅ — 49 core, 28 CLI
```

## Related

- Closes #187
- Parent: #179
