### PR TITLE
fix: replace broken todo-to-issue action (alstr→gr2m)

### DIFF
--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   schedule:
-    - cron: "31 1,12 * * *" # periodic sync of TODO comments
+    - cron: "31 1,12 * * *"
   workflow_dispatch:
 
 permissions:
@@ -22,5 +22,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: TODO to Issue
-        uses: alstr/todo-to-issue-action@v5
-        id: todo
+        uses: gr2m/todo-to-issue@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          close-issues: false
+          identifiers: "TODO|FIXME|HACK"


### PR DESCRIPTION
## Summary

The `alstr/todo-to-issue-action@v5` has been failing on main with:
```
Exception: Cannot retrieve languages data. Operation will abort.
```

The action tries to fetch GitHub's languages API during initialization and crashes when unavailable.

Replaced with `gr2m/todo-to-issue@v1` which is simpler, doesn't have the language-data dependency, and uses the standard `GITHUB_TOKEN`.

### Changes

- Switched action: `alstr/todo-to-issue-action@v5` → `gr2m/todo-to-issue@v1`
- Added `token`, `close-issues`, and `identifiers` inputs
- Cleaned up trailing comment on cron schedule