### PR TITLE
docs: align README and SVG heroes with cozy nest identity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,20 @@ Please note we have a [Code of Conduct](./.github/CODE_OF_CONDUCT.md) — follow
 
 ---
 
+## Brand and voice
+
+CNA uses a **cozy nest** identity across GitHub, npm, the website, and generated starters:
+
+- **Palette:** amber `#f59e0b` / `#d97706` + teal `#0d9488` / `#14b8a6` on warm dark surfaces (`#0f172a`)
+- **Tagline:** `One command. Any stack.`
+- **Story:** choose template → add addons → ship
+- **Template design source of truth:** [`cna-templates/docs/DEFAULT_LANDING_DESIGN.md`](https://github.com/Create-Node-App/cna-templates/blob/main/docs/DEFAULT_LANDING_DESIGN.md) and [`shared/assets/`](https://github.com/Create-Node-App/cna-templates/tree/main/shared/assets)
+- **Repo heroes:** `assets/repo-hero.svg` (contributors) and `packages/create-awesome-node-app/assets/hero.svg` (npm)
+
+Prefer warm, craft-forward copy over neon/cyberpunk or generic purple SaaS framing.
+
+---
+
 ## 🐛 Reporting Bugs
 
 Use the [GitHub issue tracker](https://github.com/Create-Node-App/create-node-app/issues) to report bugs.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 # Create Awesome Node App
 
-**The open-source monorepo behind `create-awesome-node-app`: a composable scaffolding CLI for production-ready Node, Web, Full-Stack, Monorepo, and AI-ready projects.**
+**The open-source monorepo behind `create-awesome-node-app`: compose templates and addons into production-ready Node, Web, Full-Stack, Monorepo, and AI-ready projects.**
+
+One command. Any stack.
 
 [![Awesome](https://awesome.re/mentioned-badge.svg)](https://github.com/vitejs/awesome-vite#get-started)
 [![Tests][testsbadge]][testsurl]
@@ -59,7 +61,7 @@ More examples live in the [CLI package README](./packages/create-awesome-node-ap
 This is a Node 22+ monorepo managed with npm workspaces and [Turborepo](https://turbo.build/).
 
 | Path                                                                     | Purpose                                                                                                                                |
-|--------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
 | [`packages/create-awesome-node-app`](./packages/create-awesome-node-app) | Main CLI package, Commander entrypoint, interactive wizard, catalog listing, and package metadata.                                     |
 | [`packages/create-node-app-core`](./packages/create-node-app-core)       | Scaffolding engine: resolves templates/extensions, copies files, applies template options, installs dependencies, and initializes git. |
 | [`packages/eslint-config-base`](./packages/eslint-config-base)           | Shared base ESLint flat config.                                                                                                        |
@@ -67,7 +69,7 @@ This is a Node 22+ monorepo managed with npm workspaces and [Turborepo](https://
 | [`packages/eslint-config-react`](./packages/eslint-config-react)         | React ESLint config extending the TypeScript preset.                                                                                   |
 | [`packages/eslint-config-next`](./packages/eslint-config-next)           | Next.js ESLint config extending the TypeScript preset.                                                                                 |
 | [`packages/tsconfig`](./packages/tsconfig)                               | Shared TypeScript base configurations.                                                                                                 |
-| [`docs/`](./docs)                                                        | Troubleshooting and migration notes.                                                                                                   |
+| [`docs/`](./docs)                                                        | Brand guidance, troubleshooting, and migration notes.                                                                                  |
 | [`.github/workflows`](./.github/workflows)                               | CI for tests, lint, typecheck, shellcheck, markdown, and release automation.                                                           |
 
 Template and extension data is maintained in [`Create-Node-App/cna-templates`](https://github.com/Create-Node-App/cna-templates). This repo consumes that catalog remotely.
@@ -175,7 +177,7 @@ npx create-awesome-node-app local-app \
 ## Quality Checks
 
 | Command                 | What it validates                                          |
-|-------------------------|------------------------------------------------------------|
+| ----------------------- | ---------------------------------------------------------- |
 | `npm run build`         | Builds all packages through Turborepo.                     |
 | `npm run test`          | Runs package test tasks.                                   |
 | `npm run test:all`      | Runs all Node native test files under `packages/**/tests`. |
@@ -249,7 +251,7 @@ npx create-awesome-node-app --template react-vite-boilerplate --list-addons
 Common template slugs:
 
 | Slug                              | Description                                                                                           |
-|-----------------------------------|-------------------------------------------------------------------------------------------------------|
+| --------------------------------- | ----------------------------------------------------------------------------------------------------- |
 | `react-vite-boilerplate`          | React + Vite + TypeScript starter.                                                                    |
 | `nextjs-starter`                  | Production-ready Next.js starter.                                                                     |
 | `nextjs-saas-ai-starter`          | Multi-tenant SaaS starter with AI, Auth.js, Drizzle, PostgreSQL, Tailwind, shadcn/ui, RBAC, and i18n. |
@@ -264,7 +266,7 @@ Common template slugs:
 Common addon slugs:
 
 | Category       | Examples                                                                         |
-|----------------|----------------------------------------------------------------------------------|
+| -------------- | -------------------------------------------------------------------------------- |
 | UI             | `tailwind-css`, `material-ui`, `shadcn-ui`, `nextjs-shadcn`                      |
 | State and data | `zustand`, `jotai`, `tanstack-react-query`, `apollo-client`                      |
 | Backend and DB | `drizzle-orm-postgresql`, `drizzle-orm-sqlite`, `mongoose-orm-mongodb`           |

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ More examples live in the [CLI package README](./packages/create-awesome-node-ap
 This is a Node 22+ monorepo managed with npm workspaces and [Turborepo](https://turbo.build/).
 
 | Path                                                                     | Purpose                                                                                                                                |
-| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+|--------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
 | [`packages/create-awesome-node-app`](./packages/create-awesome-node-app) | Main CLI package, Commander entrypoint, interactive wizard, catalog listing, and package metadata.                                     |
 | [`packages/create-node-app-core`](./packages/create-node-app-core)       | Scaffolding engine: resolves templates/extensions, copies files, applies template options, installs dependencies, and initializes git. |
 | [`packages/eslint-config-base`](./packages/eslint-config-base)           | Shared base ESLint flat config.                                                                                                        |
@@ -177,7 +177,7 @@ npx create-awesome-node-app local-app \
 ## Quality Checks
 
 | Command                 | What it validates                                          |
-| ----------------------- | ---------------------------------------------------------- |
+|-------------------------|------------------------------------------------------------|
 | `npm run build`         | Builds all packages through Turborepo.                     |
 | `npm run test`          | Runs package test tasks.                                   |
 | `npm run test:all`      | Runs all Node native test files under `packages/**/tests`. |
@@ -251,7 +251,7 @@ npx create-awesome-node-app --template react-vite-boilerplate --list-addons
 Common template slugs:
 
 | Slug                              | Description                                                                                           |
-| --------------------------------- | ----------------------------------------------------------------------------------------------------- |
+|-----------------------------------|-------------------------------------------------------------------------------------------------------|
 | `react-vite-boilerplate`          | React + Vite + TypeScript starter.                                                                    |
 | `nextjs-starter`                  | Production-ready Next.js starter.                                                                     |
 | `nextjs-saas-ai-starter`          | Multi-tenant SaaS starter with AI, Auth.js, Drizzle, PostgreSQL, Tailwind, shadcn/ui, RBAC, and i18n. |
@@ -266,7 +266,7 @@ Common template slugs:
 Common addon slugs:
 
 | Category       | Examples                                                                         |
-| -------------- | -------------------------------------------------------------------------------- |
+|----------------|----------------------------------------------------------------------------------|
 | UI             | `tailwind-css`, `material-ui`, `shadcn-ui`, `nextjs-shadcn`                      |
 | State and data | `zustand`, `jotai`, `tanstack-react-query`, `apollo-client`                      |
 | Backend and DB | `drizzle-orm-postgresql`, `drizzle-orm-sqlite`, `mongoose-orm-mongodb`           |

--- a/assets/repo-hero.svg
+++ b/assets/repo-hero.svg
@@ -1,24 +1,24 @@
 <svg width="1280" height="640" viewBox="0 0 1280 640" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
   <title id="title">Create Node App Monorepo</title>
-  <desc id="desc">Clean hero banner for the Create Node App repository with separated text and contribution workflow panels.</desc>
+  <desc id="desc">Cozy nest hero banner for the Create Node App repository with contribution workflow panels.</desc>
   <defs>
     <linearGradient id="repo-bg" x1="0" y1="0" x2="1280" y2="640" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#07111F"/>
-      <stop offset="0.55" stop-color="#101827"/>
-      <stop offset="1" stop-color="#06283A"/>
+      <stop stop-color="#0f172a"/>
+      <stop offset="0.55" stop-color="#1e293b"/>
+      <stop offset="1" stop-color="#134e4a"/>
     </linearGradient>
     <linearGradient id="repo-edge" x1="96" y1="84" x2="1184" y2="558" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#0EA5E9"/>
-      <stop offset="0.5" stop-color="#22C55E"/>
-      <stop offset="1" stop-color="#F59E0B"/>
+      <stop stop-color="#f59e0b"/>
+      <stop offset="0.55" stop-color="#d97706"/>
+      <stop offset="1" stop-color="#0d9488"/>
     </linearGradient>
     <radialGradient id="repo-glow-a" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(268 190) rotate(42) scale(450 270)">
-      <stop stop-color="#0EA5E9" stop-opacity="0.4"/>
-      <stop offset="1" stop-color="#0EA5E9" stop-opacity="0"/>
+      <stop stop-color="#f59e0b" stop-opacity="0.35"/>
+      <stop offset="1" stop-color="#f59e0b" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="repo-glow-b" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(990 410) rotate(138) scale(480 300)">
-      <stop stop-color="#22C55E" stop-opacity="0.38"/>
-      <stop offset="1" stop-color="#22C55E" stop-opacity="0"/>
+      <stop stop-color="#0d9488" stop-opacity="0.35"/>
+      <stop offset="1" stop-color="#0d9488" stop-opacity="0"/>
     </radialGradient>
     <pattern id="repo-grid" width="42" height="42" patternUnits="userSpaceOnUse">
       <path d="M42 0H0V42" stroke="#94A3B8" stroke-opacity="0.07"/>
@@ -34,21 +34,21 @@
   <rect width="1280" height="640" rx="34" fill="url(#repo-glow-b)"/>
 
   <g filter="url(#repo-shadow)">
-    <rect x="96" y="84" width="1088" height="476" rx="32" fill="#06111F" stroke="url(#repo-edge)" stroke-opacity="0.72"/>
-    <rect x="96" y="84" width="1088" height="72" rx="32" fill="#0F172A" fill-opacity="0.92"/>
+    <rect x="96" y="84" width="1088" height="476" rx="32" fill="#0f172a" stroke="url(#repo-edge)" stroke-opacity="0.72"/>
+    <rect x="96" y="84" width="1088" height="72" rx="32" fill="#1e293b" fill-opacity="0.92"/>
     <circle cx="144" cy="120" r="8" fill="#EF4444"/>
     <circle cx="174" cy="120" r="8" fill="#F59E0B"/>
-    <circle cx="204" cy="120" r="8" fill="#22C55E"/>
+    <circle cx="204" cy="120" r="8" fill="#0d9488"/>
     <text x="640" y="127" text-anchor="middle" fill="#CBD5E1" font-family="Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif" font-size="18" font-weight="700">create-node-app monorepo</text>
   </g>
 
   <g filter="url(#repo-shadow)">
-    <rect x="146" y="198" width="522" height="284" rx="28" fill="#020617" fill-opacity="0.88" stroke="#1E293B"/>
+    <rect x="146" y="198" width="522" height="284" rx="28" fill="#020617" fill-opacity="0.88" stroke="#334155"/>
   </g>
 
   <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif">
-    <rect x="184" y="234" width="154" height="38" rx="19" fill="#0EA5E9" fill-opacity="0.18" stroke="#67E8F9" stroke-opacity="0.62"/>
-    <text x="261" y="258" text-anchor="middle" fill="#CFFAFE" font-size="15" font-weight="800" letter-spacing="0.8">OPEN SOURCE</text>
+    <rect x="184" y="234" width="154" height="38" rx="19" fill="#f59e0b" fill-opacity="0.16" stroke="#fcd34d" stroke-opacity="0.62"/>
+    <text x="261" y="258" text-anchor="middle" fill="#FEF3C7" font-size="15" font-weight="800" letter-spacing="0.8">OPEN SOURCE</text>
 
     <text x="184" y="324" fill="#F8FAFC" font-size="44" font-weight="900" letter-spacing="-1.2">Understand the repo.</text>
     <text x="184" y="376" fill="#E2E8F0" font-size="44" font-weight="900" letter-spacing="-1.2">Contribute faster.</text>
@@ -56,30 +56,30 @@
   </g>
 
   <g font-family="JetBrains Mono, SFMono-Regular, Consolas, monospace">
-    <rect x="184" y="450" width="382" height="42" rx="13" fill="#0B1226" stroke="#22D3EE" stroke-opacity="0.58"/>
-    <text x="206" y="477" fill="#67E8F9" font-size="16" font-weight="700">npm install &amp;&amp; npm run build</text>
+    <rect x="184" y="450" width="382" height="42" rx="13" fill="#0B1226" stroke="#0d9488" stroke-opacity="0.7"/>
+    <text x="206" y="477" fill="#5eead4" font-size="16" font-weight="700">npm install &amp;&amp; npm run build</text>
   </g>
 
   <g filter="url(#repo-shadow)">
-    <rect x="738" y="196" width="384" height="292" rx="28" fill="#020617" fill-opacity="0.78" stroke="#1E293B"/>
+    <rect x="738" y="196" width="384" height="292" rx="28" fill="#020617" fill-opacity="0.78" stroke="#334155"/>
   </g>
 
   <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif" font-weight="800">
-    <rect x="792" y="244" width="276" height="42" rx="21" fill="#0EA5E9" fill-opacity="0.17" stroke="#67E8F9" stroke-opacity="0.66"/>
-    <text x="930" y="271" text-anchor="middle" fill="#CFFAFE" font-size="15">CLI PACKAGE</text>
+    <rect x="792" y="244" width="276" height="42" rx="21" fill="#f59e0b" fill-opacity="0.16" stroke="#fcd34d" stroke-opacity="0.66"/>
+    <text x="930" y="271" text-anchor="middle" fill="#FEF3C7" font-size="15">CLI PACKAGE</text>
     <path d="M930 294V312" stroke="#64748B" stroke-width="2" stroke-linecap="round"/>
 
-    <rect x="792" y="320" width="276" height="42" rx="21" fill="#22C55E" fill-opacity="0.17" stroke="#86EFAC" stroke-opacity="0.66"/>
-    <text x="930" y="347" text-anchor="middle" fill="#DCFCE7" font-size="15">CORE ENGINE</text>
+    <rect x="792" y="320" width="276" height="42" rx="21" fill="#0d9488" fill-opacity="0.18" stroke="#5eead4" stroke-opacity="0.66"/>
+    <text x="930" y="347" text-anchor="middle" fill="#ccfbf1" font-size="15">CORE ENGINE</text>
     <path d="M930 370V388" stroke="#64748B" stroke-width="2" stroke-linecap="round"/>
 
-    <rect x="792" y="396" width="276" height="42" rx="21" fill="#F59E0B" fill-opacity="0.16" stroke="#FCD34D" stroke-opacity="0.66"/>
+    <rect x="792" y="396" width="276" height="42" rx="21" fill="#d97706" fill-opacity="0.16" stroke="#fbbf24" stroke-opacity="0.66"/>
     <text x="930" y="423" text-anchor="middle" fill="#FEF3C7" font-size="15">CI + DOCS + RELEASES</text>
   </g>
 
   <g opacity="0.85">
-    <circle cx="1102" cy="214" r="5" fill="#22D3EE"/>
-    <circle cx="1126" cy="468" r="5" fill="#4ADE80"/>
-    <circle cx="704" cy="178" r="4" fill="#FCD34D"/>
+    <circle cx="1102" cy="214" r="5" fill="#f59e0b"/>
+    <circle cx="1126" cy="468" r="5" fill="#0d9488"/>
+    <circle cx="704" cy="178" r="4" fill="#fcd34d"/>
   </g>
 </svg>

--- a/docs/BRAND.md
+++ b/docs/BRAND.md
@@ -1,0 +1,35 @@
+# Brand and voice
+
+Canonical visual identity for Create Awesome Node App across GitHub, npm, the website, and generated starters.
+
+## Identity
+
+**Cozy nest / warm workbench** — craft-forward developer tooling that feels warm, polished, and trustworthy.
+
+| Token    | Value                 | Use                              |
+| -------- | --------------------- | -------------------------------- |
+| Amber    | `#f59e0b` / `#d97706` | Primary accent, CTAs, highlights |
+| Teal     | `#0d9488` / `#14b8a6` | Secondary accent, success, links |
+| Dark bg  | `#0f172a`             | Default surfaces                 |
+| Light bg | `#fffcf5`             | Light-mode surfaces              |
+
+Primary gradient: `135deg, #f59e0b → #d97706 → #0d9488`.
+
+## Messaging
+
+- **Tagline:** One command. Any stack.
+- **Story:** choose template → add addons → ship
+- **Audience split:** root README = contributors; package README = npm users; website = conversion + catalog
+
+## Source of truth
+
+- Template landings and shared marks: [`Create-Node-App/cna-templates`](https://github.com/Create-Node-App/cna-templates) — `docs/DEFAULT_LANDING_DESIGN.md`, `shared/assets/`
+- Repo heroes: `assets/repo-hero.svg`, `packages/create-awesome-node-app/assets/hero.svg`
+- Marketing site: [`Create-Node-App/website`](https://github.com/Create-Node-App/website)
+
+## Do / don't
+
+- Do prefer warm craft language and clear CLI CTAs
+- Do keep SVG heroes valid for GitHub/npm (no scripts, escape `&`, prefer absolute raw URLs on npm)
+- Don't use neon cyberpunk or purple/indigo SaaS as the primary brand look
+- Don't invent a second logo system outside the nest mark

--- a/docs/BRAND.md
+++ b/docs/BRAND.md
@@ -7,7 +7,7 @@ Canonical visual identity for Create Awesome Node App across GitHub, npm, the we
 **Cozy nest / warm workbench** — craft-forward developer tooling that feels warm, polished, and trustworthy.
 
 | Token    | Value                 | Use                              |
-| -------- | --------------------- | -------------------------------- |
+|----------|-----------------------|----------------------------------|
 | Amber    | `#f59e0b` / `#d97706` | Primary accent, CTAs, highlights |
 | Teal     | `#0d9488` / `#14b8a6` | Secondary accent, success, links |
 | Dark bg  | `#0f172a`             | Default surfaces                 |

--- a/packages/create-awesome-node-app/README.md
+++ b/packages/create-awesome-node-app/README.md
@@ -6,9 +6,9 @@
 
 # Create Awesome Node App
 
-**🚀 Generate production-ready apps by composing templates, addons, and AI-ready conventions.**
+**One command. Any stack.** Generate production-ready apps by composing templates, addons, and AI-ready conventions.
 
-From blank folder to working Node/Web project with modern tooling, clean defaults, and team-friendly automation.
+From blank folder to a working Node/Web project with modern tooling, cozy defaults, and team-friendly automation.
 
 [![npm][npmversion]][npmurl]
 [![Downloads][npmdownloads]][npmurl]
@@ -46,7 +46,7 @@ npx create-awesome-node-app my-app \
 ```
 
 | If you want...                | Start here                                        |
-|-------------------------------|---------------------------------------------------|
+| ----------------------------- | ------------------------------------------------- |
 | A guided local setup          | `npm create awesome-node-app@latest my-app`       |
 | A repeatable CI/platform flow | `--no-interactive` with explicit flags            |
 | Your company starter          | `--template <github-url>` or `--template file://` |
@@ -56,11 +56,11 @@ npx create-awesome-node-app my-app \
 
 ## ✨ Why CNA?
 
-| Capability                        | Value                                                                                                 |
-|-----------------------------------|-------------------------------------------------------------------------------------------------------|
-| 🧩 **Composable by design**       | Start with a template, then layer only the addons your project actually needs.                        |
+| Capability                       | Value                                                                                                 |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| 🧩 **Composable by design**      | Start with a template, then layer only the addons your project actually needs.                        |
 | 🛡️ **Production-ready defaults** | TypeScript, linting, scripts, testing paths, and practical DX defaults out of the box.                |
-| 🤖 **AI-ready from day one**      | Supported templates generate `AGENTS.md` so coding agents understand the project context.             |
+| 🤖 **AI-ready from day one**     | Supported templates generate `AGENTS.md` so coding agents understand the project context.             |
 | 🏗️ **CI and platform friendly**  | Use `--no-interactive`, `--set`, `--template <url>`, and `--extend <url>` for repeatable scaffolding. |
 
 ---
@@ -80,7 +80,7 @@ You can mix catalog templates and addons with your own GitHub or `file://` sourc
 ### 🧱 Template Families
 
 | Category      | Example templates                                           |
-|---------------|-------------------------------------------------------------|
+| ------------- | ----------------------------------------------------------- |
 | Frontend      | `react-vite-boilerplate`, `astro-starter`                   |
 | Backend       | `nestjs-boilerplate`, `hono-starter`                        |
 | Full Stack    | `nextjs-starter`, `nextjs-saas-ai-starter`, `remix-starter` |
@@ -91,7 +91,7 @@ You can mix catalog templates and addons with your own GitHub or `file://` sourc
 ### 🧰 Addon Families
 
 | Category                  | Examples                                                                  |
-|---------------------------|---------------------------------------------------------------------------|
+| ------------------------- | ------------------------------------------------------------------------- |
 | UI                        | `tailwind-css`, `material-ui`, `shadcn-ui`, `nextjs-shadcn`               |
 | State and data            | `zustand`, `jotai`, `tanstack-react-query`, `apollo-client`               |
 | Backend and DB            | `drizzle-orm-postgresql`, `drizzle-orm-sqlite`, `mongoose-orm-mongodb`    |
@@ -215,7 +215,7 @@ Full catalog:
 Supported templates can generate an `AGENTS.md` file so coding assistants understand project context before editing:
 
 | Context                | Why it matters                                              |
-|------------------------|-------------------------------------------------------------|
+| ---------------------- | ----------------------------------------------------------- |
 | Project purpose        | Agents understand what the app is for before changing code. |
 | Directory layout       | Suggestions align with the real structure.                  |
 | Scripts and validation | Agents know how to lint, test, build, and verify changes.   |
@@ -230,7 +230,7 @@ Learn more: **[AGENTS.md guide](https://create-awesome-node-app.vercel.app/docs/
 Run the CLI without flags and CNA guides you through:
 
 | Step              | What you choose                                                            |
-|-------------------|----------------------------------------------------------------------------|
+| ----------------- | -------------------------------------------------------------------------- |
 | Project name      | Confirm or set the target directory                                        |
 | Package manager   | npm, yarn, pnpm, or Bun                                                    |
 | Category          | Frontend, Backend, Full Stack, Monorepo, Web Extension, UAT, or custom URL |
@@ -261,7 +261,7 @@ Usage: create-awesome-node-app [project-directory] [options]
 ```
 
 | Flag                         | Description                                           |
-|------------------------------|-------------------------------------------------------|
+| ---------------------------- | ----------------------------------------------------- |
 | `--interactive`              | Force interactive wizard (default outside CI)         |
 | `--no-interactive`           | Disable wizard and use flags only                     |
 | `-t, --template <slug\|url>` | Template slug from catalog or remote/local URL        |
@@ -341,7 +341,7 @@ cache lives at `~/.cache/cna` by default; override with `--cache-dir
 <path>` or `CNA_CACHE_DIR`.
 
 | Path                            | Contents                                   |
-|---------------------------------|--------------------------------------------|
+| ------------------------------- | ------------------------------------------ |
 | `~/.cache/cna/catalog/`         | Cached `templates.json` (one file)         |
 | `~/.cache/cna/<base64-of-url>/` | Shallow clone of one template or extension |
 
@@ -509,7 +509,7 @@ MIT © [Create Node App Contributors](https://github.com/Create-Node-App/create-
 
 **[create-awesome-node-app.vercel.app](https://create-awesome-node-app.vercel.app)**
 
-_Built for developers who value speed, composability, color, and AI-ready workflows._
+_Built for developers who value speed, composability, craft, and AI-ready workflows._
 
 </div>
 

--- a/packages/create-awesome-node-app/README.md
+++ b/packages/create-awesome-node-app/README.md
@@ -46,7 +46,7 @@ npx create-awesome-node-app my-app \
 ```
 
 | If you want...                | Start here                                        |
-| ----------------------------- | ------------------------------------------------- |
+|-------------------------------|---------------------------------------------------|
 | A guided local setup          | `npm create awesome-node-app@latest my-app`       |
 | A repeatable CI/platform flow | `--no-interactive` with explicit flags            |
 | Your company starter          | `--template <github-url>` or `--template file://` |
@@ -56,11 +56,11 @@ npx create-awesome-node-app my-app \
 
 ## ✨ Why CNA?
 
-| Capability                       | Value                                                                                                 |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| 🧩 **Composable by design**      | Start with a template, then layer only the addons your project actually needs.                        |
+| Capability                        | Value                                                                                                 |
+|-----------------------------------|-------------------------------------------------------------------------------------------------------|
+| 🧩 **Composable by design**       | Start with a template, then layer only the addons your project actually needs.                        |
 | 🛡️ **Production-ready defaults** | TypeScript, linting, scripts, testing paths, and practical DX defaults out of the box.                |
-| 🤖 **AI-ready from day one**     | Supported templates generate `AGENTS.md` so coding agents understand the project context.             |
+| 🤖 **AI-ready from day one**      | Supported templates generate `AGENTS.md` so coding agents understand the project context.             |
 | 🏗️ **CI and platform friendly**  | Use `--no-interactive`, `--set`, `--template <url>`, and `--extend <url>` for repeatable scaffolding. |
 
 ---
@@ -80,7 +80,7 @@ You can mix catalog templates and addons with your own GitHub or `file://` sourc
 ### 🧱 Template Families
 
 | Category      | Example templates                                           |
-| ------------- | ----------------------------------------------------------- |
+|---------------|-------------------------------------------------------------|
 | Frontend      | `react-vite-boilerplate`, `astro-starter`                   |
 | Backend       | `nestjs-boilerplate`, `hono-starter`                        |
 | Full Stack    | `nextjs-starter`, `nextjs-saas-ai-starter`, `remix-starter` |
@@ -91,7 +91,7 @@ You can mix catalog templates and addons with your own GitHub or `file://` sourc
 ### 🧰 Addon Families
 
 | Category                  | Examples                                                                  |
-| ------------------------- | ------------------------------------------------------------------------- |
+|---------------------------|---------------------------------------------------------------------------|
 | UI                        | `tailwind-css`, `material-ui`, `shadcn-ui`, `nextjs-shadcn`               |
 | State and data            | `zustand`, `jotai`, `tanstack-react-query`, `apollo-client`               |
 | Backend and DB            | `drizzle-orm-postgresql`, `drizzle-orm-sqlite`, `mongoose-orm-mongodb`    |
@@ -215,7 +215,7 @@ Full catalog:
 Supported templates can generate an `AGENTS.md` file so coding assistants understand project context before editing:
 
 | Context                | Why it matters                                              |
-| ---------------------- | ----------------------------------------------------------- |
+|------------------------|-------------------------------------------------------------|
 | Project purpose        | Agents understand what the app is for before changing code. |
 | Directory layout       | Suggestions align with the real structure.                  |
 | Scripts and validation | Agents know how to lint, test, build, and verify changes.   |
@@ -230,7 +230,7 @@ Learn more: **[AGENTS.md guide](https://create-awesome-node-app.vercel.app/docs/
 Run the CLI without flags and CNA guides you through:
 
 | Step              | What you choose                                                            |
-| ----------------- | -------------------------------------------------------------------------- |
+|-------------------|----------------------------------------------------------------------------|
 | Project name      | Confirm or set the target directory                                        |
 | Package manager   | npm, yarn, pnpm, or Bun                                                    |
 | Category          | Frontend, Backend, Full Stack, Monorepo, Web Extension, UAT, or custom URL |
@@ -261,7 +261,7 @@ Usage: create-awesome-node-app [project-directory] [options]
 ```
 
 | Flag                         | Description                                           |
-| ---------------------------- | ----------------------------------------------------- |
+|------------------------------|-------------------------------------------------------|
 | `--interactive`              | Force interactive wizard (default outside CI)         |
 | `--no-interactive`           | Disable wizard and use flags only                     |
 | `-t, --template <slug\|url>` | Template slug from catalog or remote/local URL        |
@@ -341,7 +341,7 @@ cache lives at `~/.cache/cna` by default; override with `--cache-dir
 <path>` or `CNA_CACHE_DIR`.
 
 | Path                            | Contents                                   |
-| ------------------------------- | ------------------------------------------ |
+|---------------------------------|--------------------------------------------|
 | `~/.cache/cna/catalog/`         | Cached `templates.json` (one file)         |
 | `~/.cache/cna/<base64-of-url>/` | Shallow clone of one template or extension |
 

--- a/packages/create-awesome-node-app/assets/hero.svg
+++ b/packages/create-awesome-node-app/assets/hero.svg
@@ -1,25 +1,25 @@
 <svg width="1280" height="640" viewBox="0 0 1280 640" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
   <title id="title">Create Awesome Node App</title>
-  <desc id="desc">A clean futuristic banner for Create Awesome Node App with separated headline, command, and composition workflow.</desc>
+  <desc id="desc">Cozy nest banner for Create Awesome Node App with headline, command, and composition workflow.</desc>
 
   <defs>
     <linearGradient id="cna-bg" x1="0" y1="0" x2="1280" y2="640" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#050816"/>
-      <stop offset="0.52" stop-color="#0B1028"/>
-      <stop offset="1" stop-color="#032436"/>
+      <stop stop-color="#0f172a"/>
+      <stop offset="0.52" stop-color="#1e293b"/>
+      <stop offset="1" stop-color="#134e4a"/>
     </linearGradient>
     <linearGradient id="cna-neon" x1="118" y1="110" x2="1162" y2="530" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#7C3AED"/>
-      <stop offset="0.5" stop-color="#06B6D4"/>
-      <stop offset="1" stop-color="#22C55E"/>
+      <stop stop-color="#f59e0b"/>
+      <stop offset="0.55" stop-color="#d97706"/>
+      <stop offset="1" stop-color="#0d9488"/>
     </linearGradient>
     <radialGradient id="cna-left-glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(270 188) rotate(45) scale(430 270)">
-      <stop stop-color="#7C3AED" stop-opacity="0.42"/>
-      <stop offset="1" stop-color="#7C3AED" stop-opacity="0"/>
+      <stop stop-color="#f59e0b" stop-opacity="0.38"/>
+      <stop offset="1" stop-color="#f59e0b" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="cna-right-glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(950 374) rotate(135) scale(470 300)">
-      <stop stop-color="#22D3EE" stop-opacity="0.45"/>
-      <stop offset="1" stop-color="#22D3EE" stop-opacity="0"/>
+      <stop stop-color="#0d9488" stop-opacity="0.4"/>
+      <stop offset="1" stop-color="#0d9488" stop-opacity="0"/>
     </radialGradient>
     <pattern id="cna-grid" width="42" height="42" patternUnits="userSpaceOnUse">
       <path d="M42 0H0V42" stroke="#94A3B8" stroke-opacity="0.07"/>
@@ -35,21 +35,21 @@
   <rect width="1280" height="640" rx="36" fill="url(#cna-right-glow)"/>
 
   <g filter="url(#cna-shadow)">
-    <rect x="96" y="82" width="1088" height="476" rx="32" fill="#06111F" stroke="url(#cna-neon)" stroke-opacity="0.72"/>
-    <rect x="96" y="82" width="1088" height="72" rx="32" fill="#0F172A" fill-opacity="0.9"/>
+    <rect x="96" y="82" width="1088" height="476" rx="32" fill="#0f172a" stroke="url(#cna-neon)" stroke-opacity="0.72"/>
+    <rect x="96" y="82" width="1088" height="72" rx="32" fill="#1e293b" fill-opacity="0.9"/>
     <circle cx="144" cy="118" r="8" fill="#EF4444"/>
     <circle cx="174" cy="118" r="8" fill="#F59E0B"/>
-    <circle cx="204" cy="118" r="8" fill="#22C55E"/>
+    <circle cx="204" cy="118" r="8" fill="#0d9488"/>
     <text x="640" y="125" text-anchor="middle" fill="#CBD5E1" font-family="Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif" font-size="18" font-weight="700">create-awesome-node-app</text>
   </g>
 
   <g filter="url(#cna-shadow)">
-    <rect x="146" y="190" width="500" height="300" rx="28" fill="#020617" fill-opacity="0.88" stroke="#1E293B"/>
+    <rect x="146" y="190" width="500" height="300" rx="28" fill="#020617" fill-opacity="0.88" stroke="#334155"/>
   </g>
 
   <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif">
-    <rect x="184" y="226" width="108" height="38" rx="19" fill="#7C3AED" fill-opacity="0.18" stroke="#A78BFA" stroke-opacity="0.62"/>
-    <text x="238" y="250" text-anchor="middle" fill="#DDD6FE" font-size="15" font-weight="800" letter-spacing="1">CNA</text>
+    <rect x="184" y="226" width="108" height="38" rx="19" fill="#f59e0b" fill-opacity="0.16" stroke="#fcd34d" stroke-opacity="0.62"/>
+    <text x="238" y="250" text-anchor="middle" fill="#FEF3C7" font-size="15" font-weight="800" letter-spacing="1">CNA</text>
 
     <text x="184" y="314" fill="#F8FAFC" font-size="48" font-weight="900" letter-spacing="-1.4">One command.</text>
     <text x="184" y="370" fill="url(#cna-neon)" font-size="48" font-weight="900" letter-spacing="-1.4">Any stack.</text>
@@ -57,31 +57,31 @@
   </g>
 
   <g font-family="JetBrains Mono, SFMono-Regular, Consolas, monospace">
-    <rect x="184" y="444" width="404" height="44" rx="14" fill="#0B1226" stroke="#22D3EE" stroke-opacity="0.6"/>
-    <text x="206" y="472" fill="#67E8F9" font-size="16" font-weight="700">npm create awesome-node-app@latest</text>
+    <rect x="184" y="444" width="404" height="44" rx="14" fill="#0B1226" stroke="#0d9488" stroke-opacity="0.7"/>
+    <text x="206" y="472" fill="#5eead4" font-size="16" font-weight="700">npm create awesome-node-app@latest</text>
   </g>
 
   <g filter="url(#cna-shadow)">
-    <rect x="714" y="196" width="378" height="288" rx="28" fill="#020617" fill-opacity="0.76" stroke="#1E293B"/>
+    <rect x="714" y="196" width="378" height="288" rx="28" fill="#020617" fill-opacity="0.76" stroke="#334155"/>
   </g>
 
   <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif" font-weight="800">
-    <rect x="780" y="250" width="246" height="46" rx="23" fill="#7C3AED" fill-opacity="0.18" stroke="#A78BFA" stroke-opacity="0.68"/>
-    <text x="903" y="279" text-anchor="middle" fill="#DDD6FE" font-size="16">TEMPLATE</text>
+    <rect x="780" y="250" width="246" height="46" rx="23" fill="#f59e0b" fill-opacity="0.16" stroke="#fcd34d" stroke-opacity="0.68"/>
+    <text x="903" y="279" text-anchor="middle" fill="#FEF3C7" font-size="16">TEMPLATE</text>
 
     <path d="M903 304V326" stroke="#64748B" stroke-width="2" stroke-linecap="round"/>
-    <rect x="780" y="334" width="246" height="46" rx="23" fill="#06B6D4" fill-opacity="0.18" stroke="#67E8F9" stroke-opacity="0.68"/>
-    <text x="903" y="363" text-anchor="middle" fill="#CFFAFE" font-size="16">ADDONS</text>
+    <rect x="780" y="334" width="246" height="46" rx="23" fill="#0d9488" fill-opacity="0.18" stroke="#5eead4" stroke-opacity="0.68"/>
+    <text x="903" y="363" text-anchor="middle" fill="#ccfbf1" font-size="16">ADDONS</text>
 
     <path d="M903 388V410" stroke="#64748B" stroke-width="2" stroke-linecap="round"/>
-    <rect x="780" y="418" width="246" height="46" rx="23" fill="#22C55E" fill-opacity="0.18" stroke="#86EFAC" stroke-opacity="0.68"/>
-    <text x="903" y="447" text-anchor="middle" fill="#DCFCE7" font-size="16">AI-READY APP</text>
+    <rect x="780" y="418" width="246" height="46" rx="23" fill="#d97706" fill-opacity="0.16" stroke="#fbbf24" stroke-opacity="0.68"/>
+    <text x="903" y="447" text-anchor="middle" fill="#FEF3C7" font-size="16">AI-READY APP</text>
   </g>
 
   <g opacity="0.9">
-    <circle cx="1098" cy="212" r="5" fill="#22D3EE"/>
-    <circle cx="1128" cy="286" r="4" fill="#A78BFA"/>
-    <circle cx="1108" cy="474" r="5" fill="#22C55E"/>
-    <circle cx="694" cy="168" r="4" fill="#67E8F9"/>
+    <circle cx="1098" cy="212" r="5" fill="#f59e0b"/>
+    <circle cx="1128" cy="286" r="4" fill="#0d9488"/>
+    <circle cx="1108" cy="474" r="5" fill="#fcd34d"/>
+    <circle cx="694" cy="168" r="4" fill="#5eead4"/>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- Restyle `assets/repo-hero.svg` and package `hero.svg` to the amber/teal nest palette
- Align package/root README messaging with the brand tagline while keeping audience split
- Add `docs/BRAND.md` and a CONTRIBUTING brand pointer

## Related
- Closes #207
- Closes #208
- Closes #209
- Closes #210
- Closes #211
- Cross-repo: Create-Node-App/website#6, Create-Node-App/cna-templates#194, Create-Node-App/.github#6

## Test plan
- [ ] SVGs are well-formed XML and render on GitHub
- [ ] Package README still uses absolute raw GitHub URL for the hero image
- [ ] `prettier --check` on touched markdown files
- [ ] Root README remains contributor-focused; package README remains user-focused


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added brand and voice guidance for the project, including color palette, tagline, story direction, and approved design references.
  * Expanded contributor guidance with clearer rules for writing style and visual identity.
  * Updated README and package messaging to better reflect the project’s positioning and keep marketing copy consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->