### PR TITLE
feat(distribution): add Homebrew, AUR, and Docker publish pipelines

### DIFF
--- a/.github/workflows/notify-homebrew.yml
+++ b/.github/workflows/notify-homebrew.yml
@@ -1,0 +1,48 @@
+name: Notify Homebrew tap
+
+# Triggers on Changesets-created tags for the CLI package. Sends a
+# repository_dispatch event to Create-Node-App/homebrew-tap so its
+# update-formula workflow can bump the formula and push it.
+on:
+  push:
+    tags:
+      - "create-awesome-node-app@*"
+  # Manual trigger to re-notify for a specific version.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Package version (e.g. 0.12.0)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    name: Dispatch to homebrew-tap
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve version
+        id: version
+        env:
+          TAG_REF: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="${TAG_REF#create-awesome-node-app@}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch repository event
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/Create-Node-App/homebrew-tap/dispatches \
+            -f "event_type=new-release" \
+            -f "client_payload[version]=$VERSION"

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -1,0 +1,47 @@
+name: Publish to AUR
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  aur:
+    name: Update AUR package
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get published version
+        id: version
+        run: |
+          VERSION=$(curl -s https://registry.npmjs.org/create-awesome-node-app/latest | jq -r '.version')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout aur-package repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
+        with:
+          repository: Create-Node-App/aur-package
+          token: ${{ secrets.AUR_REPO_TOKEN }}
+          path: aur-package
+
+      - name: Update PKGBUILD version
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          cd aur-package
+          sed -i "s/^pkgver=.*/pkgver=${NEW_VERSION}/" PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+
+      - name: Publish to AUR
+        uses: ulises-jeremias/github-actions-aur-publish@v2
+        with:
+          pkgname: create-awesome-node-app
+          pkgver: ${{ steps.version.outputs.version }}
+          commit_username: "Create Node App Bot"
+          commit_email: "ulisescf.24@gmail.com"
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          updpkgsums: true
+          allow_empty_commits: false

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -21,7 +21,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Checkout aur-package repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: Create-Node-App/aur-package
           token: ${{ secrets.AUR_REPO_TOKEN }}
@@ -36,7 +36,7 @@ jobs:
           sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
 
       - name: Publish to AUR
-        uses: ulises-jeremias/github-actions-aur-publish@v2
+        uses: ulises-jeremias/github-actions-aur-publish@217e4e2abbbee9ecc942bdc0681302e233656d9f # v1
         with:
           pkgname: create-awesome-node-app
           pkgver: ${{ steps.version.outputs.version }}

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -51,9 +51,15 @@ jobs:
           sed -i "s/^pkgver=.*/pkgver=${NEW_VERSION}/" PKGBUILD
           sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
 
-          # Fetch new npm tarball and compute sha256
+          # Fetch new npm tarball and compute sha256. -f makes curl exit
+          # non-zero on 4xx/5xx so we never silently hash an error page
+          # (e.g. tarball not yet propagated through npm's CDN).
           URL="https://registry.npmjs.org/create-awesome-node-app/-/create-awesome-node-app-${NEW_VERSION}.tgz"
-          SHA=$(curl -sL "$URL" | sha256sum | cut -d' ' -f1)
+          SHA=$(curl -sfL "$URL" | sha256sum | cut -d' ' -f1)
+          if [ -z "$SHA" ] || [ "$SHA" = "d41d8cd98f00b204e9800998ecf8427e" ]; then
+            echo "::error::Failed to download or hash tarball at $URL" >&2
+            exit 1
+          fi
           sed -i "s/^sha256sums=.*/sha256sums=('${SHA}')/" PKGBUILD
 
           echo "----- Updated PKGBUILD -----"

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -1,9 +1,18 @@
 name: Publish to AUR
 
+# Triggers on Changesets-created tags for the CLI package.
+# Publishes the updated PKGBUILD to aur.archlinux.org and keeps the
+# Create-Node-App/aur-package GitHub mirror in sync.
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types: [completed]
+  push:
+    tags:
+      - "create-awesome-node-app@*"
+  # Manual trigger to re-publish an existing version.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Package version (e.g. 0.12.0)"
+        required: true
 
 permissions:
   contents: read
@@ -11,37 +20,66 @@ permissions:
 jobs:
   aur:
     name: Update AUR package
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Get published version
+      - name: Resolve version
         id: version
+        env:
+          TAG_REF: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          VERSION=$(curl -s https://registry.npmjs.org/create-awesome-node-app/latest | jq -r '.version')
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="${TAG_REF#create-awesome-node-app@}"
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout aur-package repo
+      - name: Checkout aur-package mirror repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: Create-Node-App/aur-package
           token: ${{ secrets.AUR_REPO_TOKEN }}
           path: aur-package
 
-      - name: Update PKGBUILD version
+      - name: Update PKGBUILD (version + sha256)
+        working-directory: aur-package
         env:
           NEW_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          cd aur-package
+          # Reset pkgver and pkgrel
           sed -i "s/^pkgver=.*/pkgver=${NEW_VERSION}/" PKGBUILD
           sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
 
+          # Fetch new npm tarball and compute sha256
+          URL="https://registry.npmjs.org/create-awesome-node-app/-/create-awesome-node-app-${NEW_VERSION}.tgz"
+          SHA=$(curl -sL "$URL" | sha256sum | cut -d' ' -f1)
+          sed -i "s/^sha256sums=.*/sha256sums=('${SHA}')/" PKGBUILD
+
+          echo "----- Updated PKGBUILD -----"
+          cat PKGBUILD
+
       - name: Publish to AUR
+        # Pushes to aur.archlinux.org via SSH. The action reads the
+        # updated PKGBUILD, regenerates .SRCINFO, and pushes.
         uses: ulises-jeremias/github-actions-aur-publish@217e4e2abbbee9ecc942bdc0681302e233656d9f # v1
         with:
           pkgname: create-awesome-node-app
-          pkgver: ${{ steps.version.outputs.version }}
+          pkgbuild: aur-package/PKGBUILD
           commit_username: "Create Node App Bot"
           commit_email: "ulisescf.24@gmail.com"
+          commit_message: "Update to version ${{ steps.version.outputs.version }}"
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-          updpkgsums: true
-          allow_empty_commits: false
+          allow_empty_commits: "false"
+
+      - name: Sync updated PKGBUILD to GitHub mirror
+        # Keep the aur-package GitHub mirror in sync with what's live
+        # on AUR. Only PKGBUILD needs to be committed here — .SRCINFO
+        # is regenerated automatically by AUR from PKGBUILD.
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
+        with:
+          repository: aur-package
+          commit_message: "chore: sync PKGBUILD for v${{ steps.version.outputs.version }}"
+          commit_user_name: "Create Node App Bot"
+          commit_user_email: "ulisescf.24@gmail.com"
+          file_pattern: "PKGBUILD"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -39,9 +39,11 @@ jobs:
           fi
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
           MINOR=$(echo "$VERSION" | cut -d. -f2)
-          echo "version=$VERSION"    >> "$GITHUB_OUTPUT"
-          echo "major=$MAJOR"        >> "$GITHUB_OUTPUT"
-          echo "minor=$MINOR"        >> "$GITHUB_OUTPUT"
+          {
+            echo "version=$VERSION"
+            echo "major=$MAJOR"
+            echo "minor=$MINOR"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -78,5 +80,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,46 @@
+name: Publish Docker image
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  docker:
+    name: Build and push Docker image
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
+
+      - name: Get published version
+        id: version
+        run: |
+          VERSION=$(curl -s https://registry.npmjs.org/create-awesome-node-app/latest | jq -r '.version')
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "major=$MAJOR"     >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec8b00b2c8e # v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6
+        with:
+          context: .
+          push: true
+          tags: |
+            create-awesome-node-app/cli:latest
+            create-awesome-node-app/cli:${{ steps.version.outputs.version }}
+            create-awesome-node-app/cli:v${{ steps.version.outputs.major }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,9 +1,19 @@
 name: Publish Docker image
 
+# Triggers on Changesets-created tags for the CLI package. Each tag
+# push here means an actual publish to npm happened (see publish.yml
+# — `git push --follow-tags`). Version comes directly from the tag ref,
+# eliminating the need to poll the npm registry.
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types: [completed]
+  push:
+    tags:
+      - "create-awesome-node-app@*"
+  # Manual trigger to rebuild an image for an existing version.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Package version (e.g. 0.12.0)"
+        required: true
 
 permissions:
   contents: read
@@ -11,18 +21,27 @@ permissions:
 jobs:
   docker:
     name: Build and push Docker image
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Get published version
+      - name: Resolve version
         id: version
+        env:
+          TAG_REF: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          VERSION=$(curl -s https://registry.npmjs.org/create-awesome-node-app/latest | jq -r '.version')
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            # Tag format: create-awesome-node-app@X.Y.Z
+            VERSION="${TAG_REF#create-awesome-node-app@}"
+          fi
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "major=$MAJOR"     >> "$GITHUB_OUTPUT"
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          echo "version=$VERSION"    >> "$GITHUB_OUTPUT"
+          echo "major=$MAJOR"        >> "$GITHUB_OUTPUT"
+          echo "minor=$MINOR"        >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -33,14 +52,31 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: create-awesome-node-app/cli
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
+            type=raw,value=v${{ steps.version.outputs.major }}
+          labels: |
+            org.opencontainers.image.title=create-awesome-node-app
+            org.opencontainers.image.description=Composable scaffolding CLI — one command, any Node.js stack
+            org.opencontainers.image.url=https://create-awesome-node-app.vercel.app
+            org.opencontainers.image.source=https://github.com/Create-Node-App/create-node-app
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+
       - name: Build and push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: true
-          tags: |
-            create-awesome-node-app/cli:latest
-            create-awesome-node-app/cli:${{ steps.version.outputs.version }}
-            create-awesome-node-app/cli:v${{ steps.version.outputs.major }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Resolve version
         id: version
@@ -45,6 +47,13 @@ jobs:
             echo "minor=$MINOR"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Set up QEMU
+        # Required so buildx can cross-build linux/arm64 on the x86_64
+        # ubuntu-latest runner.
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: linux/arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
@@ -59,8 +68,10 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: create-awesome-node-app/cli
+          # `latest` is guarded so a manual workflow_dispatch rebuild
+          # of an older version can't overwrite the newest published tag.
           tags: |
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ github.event_name == 'push' }}
             type=raw,value=${{ steps.version.outputs.version }}
             type=raw,value=${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
             type=raw,value=v${{ steps.version.outputs.major }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Get published version
         id: version
@@ -25,16 +25,16 @@ jobs:
           echo "major=$MAJOR"     >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec8b00b2c8e # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
     environment: npm-publish
     permissions:
       id-token: write # Required for OIDC trusted publishing
-      contents: read
+      contents: write # Required to push git tags for downstream workflows
       packages: write
     steps:
       - name: Checkout
@@ -65,3 +65,11 @@ jobs:
 
       - name: Publish packages
         run: npm run publish-packages
+
+      # `changeset publish` creates lightweight tags per published
+      # package (e.g. create-awesome-node-app@0.12.0). We use --tags
+      # (not --follow-tags) because lightweight tags require it.
+      # Pushing them triggers the tag-based Docker, AUR, and Homebrew
+      # workflows.
+      - name: Push git tags
+        run: git push origin --tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:22-alpine
+
+RUN npm install -g create-awesome-node-app
+
+ENTRYPOINT ["create-awesome-node-app"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
+# syntax=docker/dockerfile:1.9
 FROM node:22-alpine
 
-RUN npm install -g create-awesome-node-app
+# VERSION is passed at build time by the publish workflow so the image
+# is pinned to a specific npm package version (satisfies hadolint DL3016
+# and makes each image reproducible for its tag).
+ARG VERSION=latest
+
+# hadolint ignore=DL3018
+RUN npm install -g "create-awesome-node-app@${VERSION}"
 
 ENTRYPOINT ["create-awesome-node-app"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,11 @@ ARG VERSION=latest
 # hadolint ignore=DL3018
 RUN npm install -g "create-awesome-node-app@${VERSION}"
 
+# node:22-alpine ships an unprivileged `node` user by default. Run as
+# that user so the scaffolded project files (mounted in via -v $PWD:/app)
+# don't end up owned by root on the host.
+USER node
+WORKDIR /home/node
+
 ENTRYPOINT ["create-awesome-node-app"]
 CMD ["--help"]

--- a/packages/create-awesome-node-app/README.md
+++ b/packages/create-awesome-node-app/README.md
@@ -69,7 +69,7 @@ npx create-awesome-node-app my-app \
 ```
 
 | If you want...                | Start here                                        |
-| ----------------------------- | ------------------------------------------------- |
+|-------------------------------|---------------------------------------------------|
 | A guided local setup          | `npm create awesome-node-app@latest my-app`       |
 | A repeatable CI/platform flow | `--no-interactive` with explicit flags            |
 | Your company starter          | `--template <github-url>` or `--template file://` |
@@ -79,11 +79,11 @@ npx create-awesome-node-app my-app \
 
 ## ✨ Why CNA?
 
-| Capability                       | Value                                                                                                 |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| 🧩 **Composable by design**      | Start with a template, then layer only the addons your project actually needs.                        |
+| Capability                        | Value                                                                                                 |
+|-----------------------------------|-------------------------------------------------------------------------------------------------------|
+| 🧩 **Composable by design**       | Start with a template, then layer only the addons your project actually needs.                        |
 | 🛡️ **Production-ready defaults** | TypeScript, linting, scripts, testing paths, and practical DX defaults out of the box.                |
-| 🤖 **AI-ready from day one**     | Supported templates generate `AGENTS.md` so coding agents understand the project context.             |
+| 🤖 **AI-ready from day one**      | Supported templates generate `AGENTS.md` so coding agents understand the project context.             |
 | 🏗️ **CI and platform friendly**  | Use `--no-interactive`, `--set`, `--template <url>`, and `--extend <url>` for repeatable scaffolding. |
 
 ---
@@ -103,7 +103,7 @@ You can mix catalog templates and addons with your own GitHub or `file://` sourc
 ### 🧱 Template Families
 
 | Category      | Example templates                                           |
-| ------------- | ----------------------------------------------------------- |
+|---------------|-------------------------------------------------------------|
 | Frontend      | `react-vite-boilerplate`, `astro-starter`                   |
 | Backend       | `nestjs-boilerplate`, `hono-starter`                        |
 | Full Stack    | `nextjs-starter`, `nextjs-saas-ai-starter`, `remix-starter` |
@@ -114,7 +114,7 @@ You can mix catalog templates and addons with your own GitHub or `file://` sourc
 ### 🧰 Addon Families
 
 | Category                  | Examples                                                                  |
-| ------------------------- | ------------------------------------------------------------------------- |
+|---------------------------|---------------------------------------------------------------------------|
 | UI                        | `tailwind-css`, `material-ui`, `shadcn-ui`, `nextjs-shadcn`               |
 | State and data            | `zustand`, `jotai`, `tanstack-react-query`, `apollo-client`               |
 | Backend and DB            | `drizzle-orm-postgresql`, `drizzle-orm-sqlite`, `mongoose-orm-mongodb`    |
@@ -238,7 +238,7 @@ Full catalog:
 Supported templates can generate an `AGENTS.md` file so coding assistants understand project context before editing:
 
 | Context                | Why it matters                                              |
-| ---------------------- | ----------------------------------------------------------- |
+|------------------------|-------------------------------------------------------------|
 | Project purpose        | Agents understand what the app is for before changing code. |
 | Directory layout       | Suggestions align with the real structure.                  |
 | Scripts and validation | Agents know how to lint, test, build, and verify changes.   |
@@ -253,7 +253,7 @@ Learn more: **[AGENTS.md guide](https://create-awesome-node-app.vercel.app/docs/
 Run the CLI without flags and CNA guides you through:
 
 | Step              | What you choose                                                            |
-| ----------------- | -------------------------------------------------------------------------- |
+|-------------------|----------------------------------------------------------------------------|
 | Project name      | Confirm or set the target directory                                        |
 | Package manager   | npm, yarn, pnpm, or Bun                                                    |
 | Category          | Frontend, Backend, Full Stack, Monorepo, Web Extension, UAT, or custom URL |
@@ -284,7 +284,7 @@ Usage: create-awesome-node-app [project-directory] [options]
 ```
 
 | Flag                         | Description                                           |
-| ---------------------------- | ----------------------------------------------------- |
+|------------------------------|-------------------------------------------------------|
 | `--interactive`              | Force interactive wizard (default outside CI)         |
 | `--no-interactive`           | Disable wizard and use flags only                     |
 | `-t, --template <slug\|url>` | Template slug from catalog or remote/local URL        |
@@ -364,7 +364,7 @@ cache lives at `~/.cache/cna` by default; override with `--cache-dir
 <path>` or `CNA_CACHE_DIR`.
 
 | Path                            | Contents                                   |
-| ------------------------------- | ------------------------------------------ |
+|---------------------------------|--------------------------------------------|
 | `~/.cache/cna/catalog/`         | Cached `templates.json` (one file)         |
 | `~/.cache/cna/<base64-of-url>/` | Shallow clone of one template or extension |
 

--- a/packages/create-awesome-node-app/README.md
+++ b/packages/create-awesome-node-app/README.md
@@ -29,10 +29,33 @@ From blank folder to a working Node/Web project with modern tooling, cozy defaul
 
 ---
 
-## ⚡ Start In 30 Seconds
+## ⚡ Install
+
+**npm (recommended):**
 
 ```bash
 npm create awesome-node-app@latest my-app
+```
+
+**Homebrew (macOS / Linux):**
+
+```bash
+brew tap Create-Node-App/tap
+brew install create-awesome-node-app
+```
+
+**AUR (Arch Linux):**
+
+```bash
+yay -S create-awesome-node-app   # or: paru -S create-awesome-node-app
+```
+
+**Docker:**
+
+```bash
+docker run --rm -it -v "${PWD}:/app" -w /app \
+  create-awesome-node-app/cli:latest my-app \
+  --template react-vite-boilerplate
 ```
 
 Interactive by default outside CI. For automation, run headless with flags:
@@ -46,7 +69,7 @@ npx create-awesome-node-app my-app \
 ```
 
 | If you want...                | Start here                                        |
-|-------------------------------|---------------------------------------------------|
+| ----------------------------- | ------------------------------------------------- |
 | A guided local setup          | `npm create awesome-node-app@latest my-app`       |
 | A repeatable CI/platform flow | `--no-interactive` with explicit flags            |
 | Your company starter          | `--template <github-url>` or `--template file://` |
@@ -56,11 +79,11 @@ npx create-awesome-node-app my-app \
 
 ## ✨ Why CNA?
 
-| Capability                        | Value                                                                                                 |
-|-----------------------------------|-------------------------------------------------------------------------------------------------------|
-| 🧩 **Composable by design**       | Start with a template, then layer only the addons your project actually needs.                        |
+| Capability                       | Value                                                                                                 |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| 🧩 **Composable by design**      | Start with a template, then layer only the addons your project actually needs.                        |
 | 🛡️ **Production-ready defaults** | TypeScript, linting, scripts, testing paths, and practical DX defaults out of the box.                |
-| 🤖 **AI-ready from day one**      | Supported templates generate `AGENTS.md` so coding agents understand the project context.             |
+| 🤖 **AI-ready from day one**     | Supported templates generate `AGENTS.md` so coding agents understand the project context.             |
 | 🏗️ **CI and platform friendly**  | Use `--no-interactive`, `--set`, `--template <url>`, and `--extend <url>` for repeatable scaffolding. |
 
 ---
@@ -80,7 +103,7 @@ You can mix catalog templates and addons with your own GitHub or `file://` sourc
 ### 🧱 Template Families
 
 | Category      | Example templates                                           |
-|---------------|-------------------------------------------------------------|
+| ------------- | ----------------------------------------------------------- |
 | Frontend      | `react-vite-boilerplate`, `astro-starter`                   |
 | Backend       | `nestjs-boilerplate`, `hono-starter`                        |
 | Full Stack    | `nextjs-starter`, `nextjs-saas-ai-starter`, `remix-starter` |
@@ -91,7 +114,7 @@ You can mix catalog templates and addons with your own GitHub or `file://` sourc
 ### 🧰 Addon Families
 
 | Category                  | Examples                                                                  |
-|---------------------------|---------------------------------------------------------------------------|
+| ------------------------- | ------------------------------------------------------------------------- |
 | UI                        | `tailwind-css`, `material-ui`, `shadcn-ui`, `nextjs-shadcn`               |
 | State and data            | `zustand`, `jotai`, `tanstack-react-query`, `apollo-client`               |
 | Backend and DB            | `drizzle-orm-postgresql`, `drizzle-orm-sqlite`, `mongoose-orm-mongodb`    |
@@ -215,7 +238,7 @@ Full catalog:
 Supported templates can generate an `AGENTS.md` file so coding assistants understand project context before editing:
 
 | Context                | Why it matters                                              |
-|------------------------|-------------------------------------------------------------|
+| ---------------------- | ----------------------------------------------------------- |
 | Project purpose        | Agents understand what the app is for before changing code. |
 | Directory layout       | Suggestions align with the real structure.                  |
 | Scripts and validation | Agents know how to lint, test, build, and verify changes.   |
@@ -230,7 +253,7 @@ Learn more: **[AGENTS.md guide](https://create-awesome-node-app.vercel.app/docs/
 Run the CLI without flags and CNA guides you through:
 
 | Step              | What you choose                                                            |
-|-------------------|----------------------------------------------------------------------------|
+| ----------------- | -------------------------------------------------------------------------- |
 | Project name      | Confirm or set the target directory                                        |
 | Package manager   | npm, yarn, pnpm, or Bun                                                    |
 | Category          | Frontend, Backend, Full Stack, Monorepo, Web Extension, UAT, or custom URL |
@@ -261,7 +284,7 @@ Usage: create-awesome-node-app [project-directory] [options]
 ```
 
 | Flag                         | Description                                           |
-|------------------------------|-------------------------------------------------------|
+| ---------------------------- | ----------------------------------------------------- |
 | `--interactive`              | Force interactive wizard (default outside CI)         |
 | `--no-interactive`           | Disable wizard and use flags only                     |
 | `-t, --template <slug\|url>` | Template slug from catalog or remote/local URL        |
@@ -341,7 +364,7 @@ cache lives at `~/.cache/cna` by default; override with `--cache-dir
 <path>` or `CNA_CACHE_DIR`.
 
 | Path                            | Contents                                   |
-|---------------------------------|--------------------------------------------|
+| ------------------------------- | ------------------------------------------ |
 | `~/.cache/cna/catalog/`         | Cached `templates.json` (one file)         |
 | `~/.cache/cna/<base64-of-url>/` | Shallow clone of one template or extension |
 

--- a/packages/create-awesome-node-app/package.json
+++ b/packages/create-awesome-node-app/package.json
@@ -32,7 +32,14 @@
     "project-generator",
     "boilerplate",
     "ai-ready",
-    "agents-md"
+    "agents-md",
+    "typescript-first",
+    "production-ready",
+    "rapid-prototyping",
+    "project-scaffolding",
+    "remix",
+    "astro",
+    "hono"
   ],
   "authors": [
     {


### PR DESCRIPTION
## Description

Adds three new distribution channels — **Homebrew**, **AUR**, and **Docker** — to reach developers who prefer their system package manager or container workflows over `npm install -g`.

### Architecture

All secondary workflows are triggered by **git tags** created by Changesets (\`create-awesome-node-app@X.Y.Z\`), not by \`workflow_run\` chaining. This is the standard pattern used by \`create-go-app\`, \`semantic-release\`, and \`GoReleaser\`.

\`\`\`
main branch push
  └─► Release workflow (publish.yml)
        ├─► release-pr job:   creates/updates Release PR (Changesets)
        └─► publish job (only when hasChangesets == false):
              ├─► npm publish (OIDC trusted publishing)
              └─► git push origin --tags  ◄─── triggers all channels

tag push (create-awesome-node-app@X.Y.Z)
  ├─► publish-docker.yml  → Docker Hub (create-awesome-node-app/cli)
  ├─► publish-aur.yml     → AUR (yay/paru) + sync to GitHub mirror
  └─► notify-homebrew.yml → repository_dispatch → homebrew-tap update
\`\`\`

### New channels

**Homebrew** — [\`Create-Node-App/homebrew-tap\`](https://github.com/Create-Node-App/homebrew-tap)

\`\`\`bash
brew tap Create-Node-App/tap
brew install create-awesome-node-app
\`\`\`

**AUR (Arch Linux)** — [\`Create-Node-App/aur-package\`](https://github.com/Create-Node-App/aur-package) mirror

\`\`\`bash
yay -S create-awesome-node-app   # or: paru -S create-awesome-node-app
\`\`\`

**Docker Hub** — [\`create-awesome-node-app/cli\`](https://hub.docker.com/r/create-awesome-node-app/cli)

\`\`\`bash
docker run --rm -it -v \"\${PWD}:/app\" -w /app \\
  create-awesome-node-app/cli:latest my-app \\
  --template react-vite-boilerplate
\`\`\`

Docker image is **multi-arch** (linux/amd64 + linux/arm64) with OCI labels and a semver tag ladder: \`latest\`, \`X.Y.Z\`, \`X.Y\`, \`vX\`.

### Other changes

- \`packages/create-awesome-node-app/README.md\`: Install section now shows all 4 methods
- \`packages/create-awesome-node-app/package.json\`: expanded keywords (\`typescript-first\`, \`production-ready\`, \`rapid-prototyping\`, \`project-scaffolding\`, \`remix\`, \`astro\`, \`hono\`)
- \`Dockerfile\`: minimal \`node:22-alpine\` wrapper

### Design decisions

**Why tag-based triggers, not \`workflow_run\`?**
- The tag is the actual signal of a successful publish — \`workflow_run\` fires even if npm publish failed mid-way.
- Version comes from \`github.ref_name\` — no need to curl the npm registry.
- Each workflow can be re-triggered manually via \`workflow_dispatch\` with a version input.
- Standard pattern; easier for future contributors to debug.

**Why keep the aur-package GitHub mirror?**
- AUR itself is the source of truth (users install from aur.archlinux.org).
- The GitHub mirror provides visibility, contribution UI, and issue tracking.
- \`publish-aur.yml\` auto-syncs PKGBUILD back after each publish, so the mirror never drifts.

**Why separate \`notify-homebrew.yml\` instead of a step in \`publish.yml\`?**
- Homebrew is triggered by the tag (like Docker/AUR), which happens in a different job from npm publish.
- Keeping the notification tag-driven means the pipeline is symmetric — all three channels react to the same signal.
- Manual re-trigger via \`workflow_dispatch\` works uniformly.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [x] YAML syntax validated on all 4 workflow files (\`yaml.safe_load\`)
- [x] Action versions verified against upstream (all pinned to SHA + version comment)
- [x] AUR action input signature verified against upstream \`action.yml\`
- [x] lint-staged passes locally
- [ ] End-to-end verification requires secrets — see below

## Required secrets (one-time setup)

Add these under **Settings → Secrets and variables → Actions** in the \`create-node-app\` repo:

| Secret | Used by | How to get |
|--------|---------|-----------|
| \`AUR_SSH_PRIVATE_KEY\` | \`publish-aur.yml\` | SSH private key registered at [aur.archlinux.org/account](https://aur.archlinux.org/) |
| \`AUR_REPO_TOKEN\` | \`publish-aur.yml\` | Fine-grained PAT with write access to \`Create-Node-App/aur-package\` |
| \`DOCKERHUB_USERNAME\` | \`publish-docker.yml\` | Docker Hub account name (must have push access to \`create-awesome-node-app\` org) |
| \`DOCKERHUB_TOKEN\` | \`publish-docker.yml\` | Docker Hub access token (Account Settings → Security) |
| \`HOMEBREW_TAP_TOKEN\` | \`notify-homebrew.yml\` | Fine-grained PAT with \`Actions: read/write\` on \`Create-Node-App/homebrew-tap\` |

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (workflow file headers explain the trigger logic)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Docker support for running the CLI, including multi-platform image distribution.
  * Added installation options through npm, Homebrew, AUR, and Docker.
  * Releases can now be distributed automatically through Docker, Homebrew, and AUR.
  * Published versions now receive corresponding release tags.

* **Documentation**
  * Expanded the quick-start guide with installation commands for each supported distribution method.

* **Chores**
  * Improved package discoverability with additional ecosystem and use-case keywords.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->