### PR TITLE
fix(ci): use 'changeset tag' explicitly to actually push release tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # Full history + existing tags so `changeset tag` can skip
+          # versions that are already tagged remotely.
+          fetch-depth: 0
+          fetch-tags: true
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -66,10 +71,16 @@ jobs:
       - name: Publish packages
         run: npm run publish-packages
 
-      # `changeset publish` creates lightweight tags per published
-      # package (e.g. create-awesome-node-app@0.12.0). We use --tags
-      # (not --follow-tags) because lightweight tags require it.
-      # Pushing them triggers the tag-based Docker, AUR, and Homebrew
-      # workflows.
+      # Our Changesets config has "commit": false, which also disables
+      # automatic tagging. Explicitly run `changeset tag` to create
+      # local git tags matching every version present in the workspace
+      # (e.g. create-awesome-node-app@0.12.0). It is a no-op for
+      # versions already tagged in the fetched history.
+      - name: Create git tags for published versions
+        run: npx changeset tag
+
+      # Push all local tags so the tag-based Docker, AUR, and Homebrew
+      # workflows trigger. Lightweight tags require --tags (not
+      # --follow-tags).
       - name: Push git tags
         run: git push origin --tags


### PR DESCRIPTION
## Description

Discovered while investigating why 0.12.0 published to npm but the tag \`create-awesome-node-app@0.12.0\` never landed on origin: our \`.changeset/config.json\` has \`\"commit\": false\`, which **also disables Changesets' automatic tagging step**. That's why the tag-based Docker, AUR, and Homebrew publish workflows have never fired — no tag has been pushed since 0.9.0.

### Root cause

\`\`\`json
// .changeset/config.json
{
  "commit": false,   // ← also disables git tag creation
  ...
}
\`\`\`

The Release workflow's log confirms it:
- \`🦋 success packages published successfully: create-awesome-node-app@0.12.0\`
- \`Everything up-to-date\` on \`git push origin --tags\` — because no tags existed locally to push.

### Fix

- **Add \`fetch-depth: 0\` + \`fetch-tags: true\`** to the publish checkout so \`changeset tag\` can compare against existing remote tags.
- **Add explicit \`npx changeset tag\`** after \`npm run publish-packages\`. This creates local git tags for every workspace package version (idempotent — skips already-tagged versions).
- Push all local tags via \`git push origin --tags\` (unchanged).

### Note

The 0.12.0 tag will be backfilled manually since the release already happened.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [x] YAML syntax validated
- [x] Root cause verified via publish job log
- [x] \`changeset tag\` is idempotent so re-running on unchanged versions is safe
- [ ] End-to-end verification will happen on the next release (0.12.1+)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing so existing versions are recognized correctly.
  * Ensured version tags are created consistently during the publishing process.
  * Prevented duplicate or incorrect tagging when publishing releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->