### PR TITLE
fix(ci): fix AUR keyscan (remove dsa) and Docker org permissions

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -77,6 +77,9 @@ jobs:
           commit_message: "Update to version ${{ steps.version.outputs.version }}"
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           allow_empty_commits: "false"
+          # dsa is no longer supported in modern OpenSSH; omit it to
+          # avoid "Unknown key type" errors during keyscan.
+          ssh_keyscan_types: "rsa,ecdsa,ed25519"
 
       - name: Sync updated PKGBUILD to GitHub mirror
         # Keep the aur-package GitHub mirror in sync with what's live


### PR DESCRIPTION
## Description

Two distribution workflow fixes:

**AUR** — `Unknown key type "dsa"`: Modern OpenSSH dropped DSA support. The action's default `ssh_keyscan_types: rsa,dsa,ecdsa,ed25519` fails immediately on the keyscan step. Fix: use `rsa,ecdsa,ed25519`.

**Docker** (manual action needed) — `insufficient_scope: authorization failed`: The DOCKERHUB_TOKEN is configured but needs push access to the `create-awesome-node-app` org. See notes below.

## Docker fix (manual)

Go to https://hub.docker.com/orgs/create-awesome-node-app/members and add the Docker Hub user matching DOCKERHUB_USERNAME as **Owner**, or create the `cli` repository manually via Docker Hub UI first.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

🤖 Generated with [Claude Code](https://claude.com/claude-code)