### PR TITLE
fix(ci): always push :latest Docker tag — remove push-only guard

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -68,10 +68,12 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ulisesjeremias/create-awesome-node-app
-          # `latest` is guarded so a manual workflow_dispatch rebuild
-          # of an older version can't overwrite the newest published tag.
+          # `latest` is pushed on tag pushes AND on explicit workflow_dispatch
+          # runs (which always execute against main, so they represent the
+          # current release). A tag push runs the workflow pinned to the
+          # tagged commit, so `push` events here are always the newest version.
           tags: |
-            type=raw,value=latest,enable=${{ github.event_name == 'push' }}
+            type=raw,value=latest
             type=raw,value=${{ steps.version.outputs.version }}
             type=raw,value=${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
             type=raw,value=v${{ steps.version.outputs.major }}


### PR DESCRIPTION
## Description

The `:latest` tag guard (`enable=${{ github.event_name == 'push' }}`) was preventing it from being pushed during `workflow_dispatch` runs. However, tag-push events run the workflow **pinned to the tagged commit**, which may predate the Docker image rename or other workflow changes. This means the guard doesn't actually protect against stale `:latest` pushes.

`workflow_dispatch` always runs against the default branch (main), so it represents the current release workflow and image name. It is safe — and desirable — to push `:latest` in both cases.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)