### PR TITLE
feat(ci): nightly distribution smoke tests + fix selectable separator bug in interactive mode

### DIFF
--- a/.github/workflows/smoke-distribution.yml
+++ b/.github/workflows/smoke-distribution.yml
@@ -1,0 +1,211 @@
+name: Distribution smoke tests
+
+# Verifies that the latest published package works correctly through
+# every distribution channel. Runs nightly and on manual trigger.
+#
+# Jobs:
+#   npm      — npx + global install on ubuntu-latest (Node 24)
+#   docker   — pull & run ulisesjeremias/create-awesome-node-app:latest
+#   homebrew — brew install on macos-latest
+#   aur      — makepkg inside an archlinux container
+#   versions — cross-check that npm, Docker, Homebrew all report the same version
+
+on:
+  schedule:
+    # 06:00 UTC every day
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Cancel any in-flight nightly if a manual run is triggered.
+concurrency:
+  group: smoke-distribution
+  cancel-in-progress: true
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────────
+  # 1. npm / npx
+  # ─────────────────────────────────────────────────────────────────────
+  npm:
+    name: npm (npx + global install)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Verify npx invocation
+        run: |
+          echo "── npx ──────────────────────────────"
+          VERSION=$(npx --yes create-awesome-node-app@latest --version 2>&1)
+          echo "npx version: $VERSION"
+          echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' || {
+            echo "::error::Unexpected version output: $VERSION"
+            exit 1
+          }
+
+      - name: Verify global install
+        run: |
+          echo "── global install ───────────────────"
+          npm install -g create-awesome-node-app@latest
+          VERSION=$(create-awesome-node-app --version 2>&1)
+          echo "global version: $VERSION"
+          echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' || {
+            echo "::error::Unexpected version output: $VERSION"
+            exit 1
+          }
+
+          echo "── help smoke ───────────────────────"
+          create-awesome-node-app --help | head -5
+
+  # ─────────────────────────────────────────────────────────────────────
+  # 2. Docker Hub
+  # ─────────────────────────────────────────────────────────────────────
+  docker:
+    name: Docker Hub (ulisesjeremias/create-awesome-node-app)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull latest image
+        run: docker pull ulisesjeremias/create-awesome-node-app:latest
+
+      - name: Verify --version
+        run: |
+          echo "── docker --version ─────────────────"
+          VERSION=$(docker run --rm ulisesjeremias/create-awesome-node-app:latest --version 2>&1)
+          echo "docker version: $VERSION"
+          echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' || {
+            echo "::error::Unexpected version output: $VERSION"
+            exit 1
+          }
+
+      - name: Verify --help
+        run: |
+          echo "── docker --help ────────────────────"
+          docker run --rm ulisesjeremias/create-awesome-node-app:latest --help | head -5
+
+  # ─────────────────────────────────────────────────────────────────────
+  # 3. Homebrew
+  # ─────────────────────────────────────────────────────────────────────
+  homebrew:
+    name: Homebrew (Create-Node-App/tap)
+    runs-on: macos-latest
+    steps:
+      - name: Tap and install
+        run: |
+          brew tap Create-Node-App/tap
+          brew install create-awesome-node-app
+
+      - name: Verify --version
+        run: |
+          echo "── brew version ─────────────────────"
+          VERSION=$(create-awesome-node-app --version 2>&1)
+          echo "homebrew version: $VERSION"
+          echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' || {
+            echo "::error::Unexpected version output: $VERSION"
+            exit 1
+          }
+
+      - name: Verify --help
+        run: |
+          echo "── brew help ────────────────────────"
+          create-awesome-node-app --help | head -5
+
+  # ─────────────────────────────────────────────────────────────────────
+  # 4. AUR — run inside an official Arch Linux container
+  # ─────────────────────────────────────────────────────────────────────
+  aur:
+    name: AUR (archlinux container)
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+    steps:
+      - name: Bootstrap Arch system and non-root builder
+        run: |
+          pacman -Sy --noconfirm --needed \
+            nodejs npm base-devel sudo git curl ca-certificates
+          # makepkg cannot run as root; create a dedicated user
+          useradd -m -G wheel builder
+          echo '%wheel ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+
+      - name: Clone AUR package and build
+        run: |
+          su builder -c "
+            set -euo pipefail
+            git clone https://aur.archlinux.org/create-awesome-node-app.git /tmp/cna
+            cd /tmp/cna
+            # Build and install (downloads from npm registry, validates sha256)
+            makepkg -si --noconfirm
+          "
+
+      - name: Verify --version
+        run: |
+          echo "── aur version ──────────────────────"
+          su builder -c "
+            VERSION=\$(create-awesome-node-app --version 2>&1)
+            echo \"aur version: \$VERSION\"
+            echo \"\$VERSION\" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\$' || {
+              echo '::error::Unexpected version output'
+              exit 1
+            }
+          "
+
+      - name: Verify --help
+        run: |
+          echo "── aur help ─────────────────────────"
+          su builder -c "create-awesome-node-app --help | head -5"
+
+  # ─────────────────────────────────────────────────────────────────────
+  # 5. Version cross-check: every channel must agree on the same version
+  # ─────────────────────────────────────────────────────────────────────
+  versions:
+    name: Cross-check published versions
+    runs-on: ubuntu-latest
+    # Run even if individual channel jobs fail — gives a full picture
+    if: always()
+    steps:
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Gather versions from each channel
+        run: |
+          set -euo pipefail
+
+          NPM=$(curl -s https://registry.npmjs.org/create-awesome-node-app/latest | \
+                python3 -c "import json,sys; print(json.load(sys.stdin)['version'])")
+
+          DOCKER=$(docker run --rm \
+                    ulisesjeremias/create-awesome-node-app:latest --version 2>/dev/null \
+                    || echo "unavailable")
+
+          HOMEBREW=$(curl -s \
+                    https://raw.githubusercontent.com/Create-Node-App/homebrew-tap/main/Formula/create-awesome-node-app.rb | \
+                    grep '^  url' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unavailable")
+
+          AUR=$(curl -s \
+                "https://aur.archlinux.org/rpc/v5/info?arg=create-awesome-node-app" | \
+                python3 -c "import json,sys; d=json.load(sys.stdin); print(d['results'][0]['Version'].split('-')[0])" \
+                || echo "unavailable")
+
+          echo "Channel versions:"
+          echo "  npm:      $NPM"
+          echo "  docker:   $DOCKER"
+          echo "  homebrew: $HOMEBREW"
+          echo "  aur:      $AUR"
+
+          # AUR is updated automatically but may lag by up to 24h — warn, don't fail
+          MISMATCH=0
+          for CHANNEL_VER in "$DOCKER" "$HOMEBREW"; do
+            if [ "$CHANNEL_VER" != "unavailable" ] && [ "$CHANNEL_VER" != "$NPM" ]; then
+              echo "::warning::Version mismatch: npm=$NPM but got $CHANNEL_VER"
+              MISMATCH=1
+            fi
+          done
+
+          if [ "$MISMATCH" -eq 1 ]; then
+            echo "::warning::Some channels are not yet on npm version $NPM"
+          else
+            echo "All channels are on $NPM ✓"
+          fi

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ More examples live in the [CLI package README](./packages/create-awesome-node-ap
 This is a Node 24+ monorepo managed with npm workspaces and [Turborepo](https://turbo.build/).
 
 | Path                                                                     | Purpose                                                                                                                                |
-| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+|--------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
 | [`packages/create-awesome-node-app`](./packages/create-awesome-node-app) | Main CLI package, Commander entrypoint, interactive wizard, catalog listing, and package metadata.                                     |
 | [`packages/create-node-app-core`](./packages/create-node-app-core)       | Scaffolding engine: resolves templates/extensions, copies files, applies template options, installs dependencies, and initializes git. |
 | [`packages/eslint-config-base`](./packages/eslint-config-base)           | Shared base ESLint flat config.                                                                                                        |
@@ -181,7 +181,7 @@ npx create-awesome-node-app local-app \
 ## Quality Checks
 
 | Command                 | What it validates                                          |
-| ----------------------- | ---------------------------------------------------------- |
+|-------------------------|------------------------------------------------------------|
 | `npm run build`         | Builds all packages through Turborepo.                     |
 | `npm run test`          | Runs package test tasks.                                   |
 | `npm run test:all`      | Runs all Node native test files under `packages/**/tests`. |
@@ -255,7 +255,7 @@ npx create-awesome-node-app --template react-vite-boilerplate --list-addons
 Common template slugs:
 
 | Slug                              | Description                                                                                           |
-| --------------------------------- | ----------------------------------------------------------------------------------------------------- |
+|-----------------------------------|-------------------------------------------------------------------------------------------------------|
 | `react-vite-boilerplate`          | React + Vite + TypeScript starter.                                                                    |
 | `nextjs-starter`                  | Production-ready Next.js starter.                                                                     |
 | `nextjs-saas-ai-starter`          | Multi-tenant SaaS starter with AI, Auth.js, Drizzle, PostgreSQL, Tailwind, shadcn/ui, RBAC, and i18n. |
@@ -270,7 +270,7 @@ Common template slugs:
 Common addon slugs:
 
 | Category       | Examples                                                                         |
-| -------------- | -------------------------------------------------------------------------------- |
+|----------------|----------------------------------------------------------------------------------|
 | UI             | `tailwind-css`, `material-ui`, `shadcn-ui`, `nextjs-shadcn`                      |
 | State and data | `zustand`, `jotai`, `tanstack-react-query`, `apollo-client`                      |
 | Backend and DB | `drizzle-orm-postgresql`, `drizzle-orm-sqlite`, `mongoose-orm-mongodb`           |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ One command. Any stack.
 [![AUR][aurbadge]][aururl]
 [![Homebrew][homebrewbadge]][homebrewurl]
 [![Docker][dockerbadge]][dockerurl]
+[![Smoke tests][smokebadge]][smokeurl]
 [![Node version](https://img.shields.io/badge/node-24%20LTS-339933?style=flat&logo=nodedotjs&logoColor=white)](.node-version)
 [![npm version](https://img.shields.io/badge/npm-11-CC3534?style=flat&logo=npm&logoColor=white)](.node-version)
 
@@ -64,7 +65,7 @@ More examples live in the [CLI package README](./packages/create-awesome-node-ap
 This is a Node 24+ monorepo managed with npm workspaces and [Turborepo](https://turbo.build/).
 
 | Path                                                                     | Purpose                                                                                                                                |
-|--------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
 | [`packages/create-awesome-node-app`](./packages/create-awesome-node-app) | Main CLI package, Commander entrypoint, interactive wizard, catalog listing, and package metadata.                                     |
 | [`packages/create-node-app-core`](./packages/create-node-app-core)       | Scaffolding engine: resolves templates/extensions, copies files, applies template options, installs dependencies, and initializes git. |
 | [`packages/eslint-config-base`](./packages/eslint-config-base)           | Shared base ESLint flat config.                                                                                                        |
@@ -180,7 +181,7 @@ npx create-awesome-node-app local-app \
 ## Quality Checks
 
 | Command                 | What it validates                                          |
-|-------------------------|------------------------------------------------------------|
+| ----------------------- | ---------------------------------------------------------- |
 | `npm run build`         | Builds all packages through Turborepo.                     |
 | `npm run test`          | Runs package test tasks.                                   |
 | `npm run test:all`      | Runs all Node native test files under `packages/**/tests`. |
@@ -254,7 +255,7 @@ npx create-awesome-node-app --template react-vite-boilerplate --list-addons
 Common template slugs:
 
 | Slug                              | Description                                                                                           |
-|-----------------------------------|-------------------------------------------------------------------------------------------------------|
+| --------------------------------- | ----------------------------------------------------------------------------------------------------- |
 | `react-vite-boilerplate`          | React + Vite + TypeScript starter.                                                                    |
 | `nextjs-starter`                  | Production-ready Next.js starter.                                                                     |
 | `nextjs-saas-ai-starter`          | Multi-tenant SaaS starter with AI, Auth.js, Drizzle, PostgreSQL, Tailwind, shadcn/ui, RBAC, and i18n. |
@@ -269,7 +270,7 @@ Common template slugs:
 Common addon slugs:
 
 | Category       | Examples                                                                         |
-|----------------|----------------------------------------------------------------------------------|
+| -------------- | -------------------------------------------------------------------------------- |
 | UI             | `tailwind-css`, `material-ui`, `shadcn-ui`, `nextjs-shadcn`                      |
 | State and data | `zustand`, `jotai`, `tanstack-react-query`, `apollo-client`                      |
 | Backend and DB | `drizzle-orm-postgresql`, `drizzle-orm-sqlite`, `mongoose-orm-mongodb`           |
@@ -343,3 +344,5 @@ _Build starters quickly. Understand the repo quickly. Contribute confidently._
 [homebrewbadge]: https://img.shields.io/badge/homebrew-Create--Node--App%2Ftap-orange?style=flat-square&logo=homebrew
 [dockerurl]: https://hub.docker.com/r/ulisesjeremias/create-awesome-node-app
 [dockerbadge]: https://img.shields.io/docker/v/ulisesjeremias/create-awesome-node-app?style=flat-square&label=Docker&logo=docker&color=2496ED
+[smokebadge]: https://github.com/Create-Node-App/create-node-app/actions/workflows/smoke-distribution.yml/badge.svg?event=schedule
+[smokeurl]: https://github.com/Create-Node-App/create-node-app/actions/workflows/smoke-distribution.yml

--- a/packages/create-awesome-node-app/README.md
+++ b/packages/create-awesome-node-app/README.md
@@ -18,6 +18,7 @@ From blank folder to a working Node/Web project with modern tooling, cozy defaul
 [![AUR][aurbadge]][aururl]
 [![Homebrew][homebrewbadge]][homebrewurl]
 [![Docker][dockerbadge]][dockerurl]
+[![Smoke tests][smokebadge]][smokeurl]
 
 [![Tests][testsbadge]][testsurl]
 [![Lint][lintbadge]][linturl]
@@ -73,7 +74,7 @@ npx create-awesome-node-app my-app \
 ```
 
 | If you want...                | Start here                                        |
-|-------------------------------|---------------------------------------------------|
+| ----------------------------- | ------------------------------------------------- |
 | A guided local setup          | `npm create awesome-node-app@latest my-app`       |
 | A repeatable CI/platform flow | `--no-interactive` with explicit flags            |
 | Your company starter          | `--template <github-url>` or `--template file://` |
@@ -83,11 +84,11 @@ npx create-awesome-node-app my-app \
 
 ## ✨ Why CNA?
 
-| Capability                        | Value                                                                                                 |
-|-----------------------------------|-------------------------------------------------------------------------------------------------------|
-| 🧩 **Composable by design**       | Start with a template, then layer only the addons your project actually needs.                        |
+| Capability                       | Value                                                                                                 |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| 🧩 **Composable by design**      | Start with a template, then layer only the addons your project actually needs.                        |
 | 🛡️ **Production-ready defaults** | TypeScript, linting, scripts, testing paths, and practical DX defaults out of the box.                |
-| 🤖 **AI-ready from day one**      | Supported templates generate `AGENTS.md` so coding agents understand the project context.             |
+| 🤖 **AI-ready from day one**     | Supported templates generate `AGENTS.md` so coding agents understand the project context.             |
 | 🏗️ **CI and platform friendly**  | Use `--no-interactive`, `--set`, `--template <url>`, and `--extend <url>` for repeatable scaffolding. |
 
 ---
@@ -107,7 +108,7 @@ You can mix catalog templates and addons with your own GitHub or `file://` sourc
 ### 🧱 Template Families
 
 | Category      | Example templates                                           |
-|---------------|-------------------------------------------------------------|
+| ------------- | ----------------------------------------------------------- |
 | Frontend      | `react-vite-boilerplate`, `astro-starter`                   |
 | Backend       | `nestjs-boilerplate`, `hono-starter`                        |
 | Full Stack    | `nextjs-starter`, `nextjs-saas-ai-starter`, `remix-starter` |
@@ -118,7 +119,7 @@ You can mix catalog templates and addons with your own GitHub or `file://` sourc
 ### 🧰 Addon Families
 
 | Category                  | Examples                                                                  |
-|---------------------------|---------------------------------------------------------------------------|
+| ------------------------- | ------------------------------------------------------------------------- |
 | UI                        | `tailwind-css`, `material-ui`, `shadcn-ui`, `nextjs-shadcn`               |
 | State and data            | `zustand`, `jotai`, `tanstack-react-query`, `apollo-client`               |
 | Backend and DB            | `drizzle-orm-postgresql`, `drizzle-orm-sqlite`, `mongoose-orm-mongodb`    |
@@ -242,7 +243,7 @@ Full catalog:
 Supported templates can generate an `AGENTS.md` file so coding assistants understand project context before editing:
 
 | Context                | Why it matters                                              |
-|------------------------|-------------------------------------------------------------|
+| ---------------------- | ----------------------------------------------------------- |
 | Project purpose        | Agents understand what the app is for before changing code. |
 | Directory layout       | Suggestions align with the real structure.                  |
 | Scripts and validation | Agents know how to lint, test, build, and verify changes.   |
@@ -257,7 +258,7 @@ Learn more: **[AGENTS.md guide](https://create-awesome-node-app.vercel.app/docs/
 Run the CLI without flags and CNA guides you through:
 
 | Step              | What you choose                                                            |
-|-------------------|----------------------------------------------------------------------------|
+| ----------------- | -------------------------------------------------------------------------- |
 | Project name      | Confirm or set the target directory                                        |
 | Package manager   | npm, yarn, pnpm, or Bun                                                    |
 | Category          | Frontend, Backend, Full Stack, Monorepo, Web Extension, UAT, or custom URL |
@@ -288,7 +289,7 @@ Usage: create-awesome-node-app [project-directory] [options]
 ```
 
 | Flag                         | Description                                           |
-|------------------------------|-------------------------------------------------------|
+| ---------------------------- | ----------------------------------------------------- |
 | `--interactive`              | Force interactive wizard (default outside CI)         |
 | `--no-interactive`           | Disable wizard and use flags only                     |
 | `-t, --template <slug\|url>` | Template slug from catalog or remote/local URL        |
@@ -368,7 +369,7 @@ cache lives at `~/.cache/cna` by default; override with `--cache-dir
 <path>` or `CNA_CACHE_DIR`.
 
 | Path                            | Contents                                   |
-|---------------------------------|--------------------------------------------|
+| ------------------------------- | ------------------------------------------ |
 | `~/.cache/cna/catalog/`         | Cached `templates.json` (one file)         |
 | `~/.cache/cna/<base64-of-url>/` | Shallow clone of one template or extension |
 
@@ -569,3 +570,5 @@ _Built for developers who value speed, composability, craft, and AI-ready workfl
 [homebrewbadge]: https://img.shields.io/badge/homebrew-Create--Node--App%2Ftap-orange?style=flat-square&logo=homebrew
 [dockerurl]: https://hub.docker.com/r/ulisesjeremias/create-awesome-node-app
 [dockerbadge]: https://img.shields.io/docker/v/ulisesjeremias/create-awesome-node-app?style=flat-square&label=Docker&logo=docker&color=2496ED
+[smokebadge]: https://github.com/Create-Node-App/create-node-app/actions/workflows/smoke-distribution.yml/badge.svg?event=schedule
+[smokeurl]: https://github.com/Create-Node-App/create-node-app/actions/workflows/smoke-distribution.yml

--- a/packages/create-awesome-node-app/README.md
+++ b/packages/create-awesome-node-app/README.md
@@ -74,7 +74,7 @@ npx create-awesome-node-app my-app \
 ```
 
 | If you want...                | Start here                                        |
-| ----------------------------- | ------------------------------------------------- |
+|-------------------------------|---------------------------------------------------|
 | A guided local setup          | `npm create awesome-node-app@latest my-app`       |
 | A repeatable CI/platform flow | `--no-interactive` with explicit flags            |
 | Your company starter          | `--template <github-url>` or `--template file://` |
@@ -84,11 +84,11 @@ npx create-awesome-node-app my-app \
 
 ## ✨ Why CNA?
 
-| Capability                       | Value                                                                                                 |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| 🧩 **Composable by design**      | Start with a template, then layer only the addons your project actually needs.                        |
+| Capability                        | Value                                                                                                 |
+|-----------------------------------|-------------------------------------------------------------------------------------------------------|
+| 🧩 **Composable by design**       | Start with a template, then layer only the addons your project actually needs.                        |
 | 🛡️ **Production-ready defaults** | TypeScript, linting, scripts, testing paths, and practical DX defaults out of the box.                |
-| 🤖 **AI-ready from day one**     | Supported templates generate `AGENTS.md` so coding agents understand the project context.             |
+| 🤖 **AI-ready from day one**      | Supported templates generate `AGENTS.md` so coding agents understand the project context.             |
 | 🏗️ **CI and platform friendly**  | Use `--no-interactive`, `--set`, `--template <url>`, and `--extend <url>` for repeatable scaffolding. |
 
 ---
@@ -108,7 +108,7 @@ You can mix catalog templates and addons with your own GitHub or `file://` sourc
 ### 🧱 Template Families
 
 | Category      | Example templates                                           |
-| ------------- | ----------------------------------------------------------- |
+|---------------|-------------------------------------------------------------|
 | Frontend      | `react-vite-boilerplate`, `astro-starter`                   |
 | Backend       | `nestjs-boilerplate`, `hono-starter`                        |
 | Full Stack    | `nextjs-starter`, `nextjs-saas-ai-starter`, `remix-starter` |
@@ -119,7 +119,7 @@ You can mix catalog templates and addons with your own GitHub or `file://` sourc
 ### 🧰 Addon Families
 
 | Category                  | Examples                                                                  |
-| ------------------------- | ------------------------------------------------------------------------- |
+|---------------------------|---------------------------------------------------------------------------|
 | UI                        | `tailwind-css`, `material-ui`, `shadcn-ui`, `nextjs-shadcn`               |
 | State and data            | `zustand`, `jotai`, `tanstack-react-query`, `apollo-client`               |
 | Backend and DB            | `drizzle-orm-postgresql`, `drizzle-orm-sqlite`, `mongoose-orm-mongodb`    |
@@ -243,7 +243,7 @@ Full catalog:
 Supported templates can generate an `AGENTS.md` file so coding assistants understand project context before editing:
 
 | Context                | Why it matters                                              |
-| ---------------------- | ----------------------------------------------------------- |
+|------------------------|-------------------------------------------------------------|
 | Project purpose        | Agents understand what the app is for before changing code. |
 | Directory layout       | Suggestions align with the real structure.                  |
 | Scripts and validation | Agents know how to lint, test, build, and verify changes.   |
@@ -258,7 +258,7 @@ Learn more: **[AGENTS.md guide](https://create-awesome-node-app.vercel.app/docs/
 Run the CLI without flags and CNA guides you through:
 
 | Step              | What you choose                                                            |
-| ----------------- | -------------------------------------------------------------------------- |
+|-------------------|----------------------------------------------------------------------------|
 | Project name      | Confirm or set the target directory                                        |
 | Package manager   | npm, yarn, pnpm, or Bun                                                    |
 | Category          | Frontend, Backend, Full Stack, Monorepo, Web Extension, UAT, or custom URL |
@@ -289,7 +289,7 @@ Usage: create-awesome-node-app [project-directory] [options]
 ```
 
 | Flag                         | Description                                           |
-| ---------------------------- | ----------------------------------------------------- |
+|------------------------------|-------------------------------------------------------|
 | `--interactive`              | Force interactive wizard (default outside CI)         |
 | `--no-interactive`           | Disable wizard and use flags only                     |
 | `-t, --template <slug\|url>` | Template slug from catalog or remote/local URL        |
@@ -369,7 +369,7 @@ cache lives at `~/.cache/cna` by default; override with `--cache-dir
 <path>` or `CNA_CACHE_DIR`.
 
 | Path                            | Contents                                   |
-| ------------------------------- | ------------------------------------------ |
+|---------------------------------|--------------------------------------------|
 | `~/.cache/cna/catalog/`         | Cached `templates.json` (one file)         |
 | `~/.cache/cna/<base64-of-url>/` | Shallow clone of one template or extension |
 

--- a/packages/create-awesome-node-app/src/options.ts
+++ b/packages/create-awesome-node-app/src/options.ts
@@ -14,41 +14,84 @@ import {
 
 const CUSTOM_TEMPLATE_SENTINEL = "__custom_template__";
 
-type SearchableChoice = prompts.Choice & {
-  _search: string;
-  _isSeparator?: boolean;
+type SearchableChoice = prompts.Choice & { _search: string };
+
+/**
+ * Derive a short (≤12 char) label from a full category name.
+ *   "Frontend Applications"   → "Frontend"
+ *   "Full Stack Applications" → "Full Stack"
+ *   "User Acceptance Testing" → "UAT"
+ *   "Monorepo Boilerplate"    → "Monorepo"
+ */
+const shortCategoryLabel = (categoryName: string): string => {
+  const stop = new Set(["Applications", "Application", "Boilerplate"]);
+  const words = categoryName.split(" ").filter((w) => !stop.has(w));
+  if (words.length >= 3)
+    return words.map((w) => w[0]?.toUpperCase() ?? "").join("");
+  return words.slice(0, 2).join(" ");
 };
 
-/** Non-selectable category heading inserted between groups of templates. */
-const makeSeparatorItem = (categoryName: string): SearchableChoice => ({
-  title: pc.dim(
-    `${"─".repeat(2)} ${categoryName} ${"─".repeat(Math.max(0, 36 - categoryName.length))}`,
-  ),
-  value: CUSTOM_TEMPLATE_SENTINEL + "__sep__",
-  disabled: true,
-  _search: "",
-  _isSeparator: true,
-});
+// Assign a distinct colour to each category slug on first use.
+const CATEGORY_PALETTE: Array<(s: string) => string> = [
+  pc.yellow,
+  pc.green,
+  pc.cyan,
+  pc.magenta,
+  pc.blue,
+  (s: string) => pc.bold(pc.green(s)),
+  (s: string) => pc.bold(pc.cyan(s)),
+];
+const _catColorCache = new Map<string, (s: string) => string>();
+let _catColorIdx = 0;
+const categoryColor = (slug: string): ((s: string) => string) => {
+  if (!_catColorCache.has(slug)) {
+    _catColorCache.set(
+      slug,
+      (CATEGORY_PALETTE[_catColorIdx++ % CATEGORY_PALETTE.length] ??
+        CATEGORY_PALETTE[0]) as (s: string) => string,
+    );
+  }
+  return _catColorCache.get(slug)!;
+};
 
-/** Selectable template or extension choice with a pre-computed search token bag. */
+/**
+ * Build a selectable choice with an optional coloured category badge
+ * and a pre-computed _search token bag so filtering works on category,
+ * name, description, and keywords.
+ */
 const makeSearchableChoice = (opts: {
   name: string;
   value: string;
   description?: string | undefined;
   labels?: string[] | undefined;
+  categorySlug?: string | undefined;
   categoryName?: string | undefined;
 }): SearchableChoice => {
-  // Show at most 3 labels as a quick-scan suffix
   const labelSuffix =
     opts.labels && opts.labels.length > 0
       ? pc.dim(" · " + opts.labels.slice(0, 3).join(", "))
       : "";
+
+  // Fixed-width 10-char badge so template names align vertically.
+  const badge = opts.categorySlug
+    ? categoryColor(opts.categorySlug)(
+        shortCategoryLabel(opts.categoryName ?? opts.categorySlug)
+          .padEnd(10)
+          .slice(0, 10),
+      )
+    : "";
+
+  const title = badge
+    ? badge + "  " + pc.bold(opts.name) + labelSuffix
+    : pc.bold(opts.name) + labelSuffix;
+
   return {
-    title: pc.bold(opts.name) + labelSuffix,
+    title,
     value: opts.value,
     description: opts.description,
     _search: [
       opts.categoryName,
+      opts.categorySlug,
       opts.name,
       opts.description ?? "",
       ...(opts.labels ?? []),
@@ -56,26 +99,19 @@ const makeSearchableChoice = (opts: {
       .filter(Boolean)
       .join(" ")
       .toLowerCase(),
-    _isSeparator: false,
   };
 };
 
-/**
- * suggest() callback for autocomplete/autocompleteMultiselect.
- *
- * When the user is typing, separator items are excluded so search
- * results are clean. When the input is empty all items including
- * separators are shown (category grouping is visible).
- */
+/** Filter by the _search token bag; works with both autocomplete types. */
 const suggestBySearchTokens = (
   input: string,
-  choices: (prompts.Choice & { _search?: string; _isSeparator?: boolean })[],
+  choices: (prompts.Choice & { _search?: string })[],
 ): Promise<prompts.Choice[]> => {
   const needle = input.trim().toLowerCase();
   if (!needle) return Promise.resolve(choices);
   return Promise.resolve(
-    choices.filter(
-      (c) => !c._isSeparator && (c._search ?? "").includes(needle),
+    choices.filter((c) =>
+      (c._search ?? c.title.toLowerCase()).includes(needle),
     ),
   );
 };
@@ -241,44 +277,34 @@ const processInteractiveOptions = async (
   // catalog at once and filter by typing.
   const allTemplates = await getAllTemplatesWithCategory();
 
-  // Build choices with visual category separators so the list is grouped
-  // when browsing. Separators are suppressed when the user types a query.
-  const templateChoices: SearchableChoice[] = [];
-  let lastCategoryName = "";
-  for (const { template, categoryName } of allTemplates) {
-    if (categoryName !== lastCategoryName) {
-      templateChoices.push(makeSeparatorItem(categoryName));
-      lastCategoryName = categoryName;
-    }
-    templateChoices.push(
+  // Build one flat list — each item has a coloured fixed-width category
+  // badge so the list is scannable without separator items.
+  // (prompts autocomplete treats disabled items as selectable, so we
+  // never use separator/divider items here.)
+  const templateChoices: SearchableChoice[] = allTemplates.map(
+    ({ template, categorySlug, categoryName }) =>
       makeSearchableChoice({
         name: template.name,
         value: template.url,
         description: template.description,
         labels: template.labels,
+        categorySlug,
         categoryName,
       }),
-    );
-  }
+  );
+
+  // "Use my own URL" entry at the bottom — no badge (custom)
   templateChoices.push({
-    title: pc.dim("── Custom") + pc.dim(" ─────────────────────────────────"),
-    value: CUSTOM_TEMPLATE_SENTINEL + "__sep__",
-    disabled: true,
-    _search: "",
-    _isSeparator: true,
-  });
-  templateChoices.push({
-    title: `${pc.italic("  Use my own template URL")}`,
+    title: "          " + "  " + pc.italic("Use my own template URL"),
     value: CUSTOM_TEMPLATE_SENTINEL,
     description: "Point at any GitHub repo or file:// path",
     _search: "custom own template url github file",
-    _isSeparator: false,
   });
 
   // Pre-select the current template (if provided via --template).
   const preselectedTemplateIdx = options.template
     ? templateChoices.findIndex((c) => c.value === options.template)
-    : 1; // skip the first separator, land on first real template
+    : 0;
 
   const baseInput = await prompts([
     {


### PR DESCRIPTION
## Description

**Two changes in one PR:**

### 1. Nightly distribution smoke tests

New `.github/workflows/smoke-distribution.yml` — runs every day at 06:00 UTC across all four distribution channels:

| Job | What it tests |
|-----|--------------|
| `npm` | `npx create-awesome-node-app@latest --version` + global install + `--help` |
| `docker` | Pull `ulisesjeremias/create-awesome-node-app:latest` + `--version` + `--help` |
| `homebrew` | `brew tap Create-Node-App/tap` + `brew install` + `--version` |
| `aur` | `archlinux:latest` container, `makepkg -si`, + `--version` |
| `versions` | Cross-check that Docker and Homebrew match the npm-latest version |

Also adds a **Smoke tests** badge to both READMEs.

### 2. Fix: category separators selectable in template autocomplete

`prompts@2.x` autocomplete does not honour `disabled: true` — users could press Enter on separator items (`── Frontend Applications ──`) and submit them as the selected template.

**Fix:** remove separator items entirely. Each choice now shows a fixed-width 10-char coloured category badge so the list is still scannable:

```
Frontend    React Vite Boilerplate · React, Vite, TypeScript
Frontend    Astro Starter · Astro, Static Site
Backend     NestJS Boilerplate · NestJS, Backend, TypeScript
Full Stac   Next.js Starter · Next.js, TypeScript, App Router
UAT         WebdriverIO Boilerplate · WebdriverIO, Selenium
```

Colours cycle per category (yellow → green → cyan → magenta → blue). Typing still filters on category name, template name, description, and keywords.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` — 39/39 pass
- [x] YAML validated for smoke workflow

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

🤖 Generated with [Claude Code](https://claude.com/claude-code)