### PR TITLE
fix(ci): trust Homebrew tap before install on macOS 15+

### DIFF
--- a/.github/workflows/smoke-distribution.yml
+++ b/.github/workflows/smoke-distribution.yml
@@ -95,6 +95,9 @@ jobs:
       - name: Tap and install
         run: |
           brew tap Create-Node-App/tap
+          # macOS 15+ requires untrusted third-party taps to be explicitly
+          # trusted before formulas from them can be installed.
+          brew trust create-node-app/tap || true
           brew install create-awesome-node-app
 
       - name: Verify --version


### PR DESCRIPTION
## Description

The smoke test Homebrew job failed with:

```
Refusing to load formula create-node-app/tap/create-awesome-node-app from untrusted tap create-node-app/tap.
Run `brew trust --formula ...` or `brew trust create-node-app/tap` to trust it.
```

macOS 15+ requires third-party taps to be explicitly trusted before formulas from them can be installed. Add `brew trust create-node-app/tap` before `brew install`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved macOS Homebrew smoke-test reliability by explicitly trusting the third-party tap before installation verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->