### PR TITLE
chore: add changeset for template separator fix (#226)

### DIFF
--- a/.changeset/fix-template-separator-selection.md
+++ b/.changeset/fix-template-separator-selection.md
@@ -1,0 +1,9 @@
+---
+"create-awesome-node-app": patch
+---
+
+Fix interactive template autocomplete submitting category separator rows.
+
+`prompts@2.x` autocomplete ignores `disabled: true`, so Enter on a divider
+could select an invalid template. Separators are removed; each choice now
+shows a fixed-width coloured category badge for scanability.


### PR DESCRIPTION
## Summary
- Adds the missing Changesets entry for the interactive template autocomplete fix that landed in #226
- Patch bump for `create-awesome-node-app` only (no other package code changes since the last Version Packages)

## Why
`main` currently has **no pending `.changeset/*.md` files**, so the Release workflow correctly reports _“No changesets present”_ and does not open a Version Packages PR.

Merging this lets `changesets/action` on push-to-`main` open the **Version Packages** release-candidate PR (recommended flow — do not hand-roll `changeset version`).

## Test plan
- [ ] After merge, Release workflow creates/updates `Version Packages` on `changeset-release/main`
- [ ] Version Packages PR bumps `create-awesome-node-app` patch and consumes this changeset
- [ ] Merging Version Packages later triggers publish + tags


Made with [Cursor](https://cursor.com)