### PR TITLE
ci: wait for npm before Docker/AUR/Homebrew

### DIFF
--- a/.github/workflows/notify-homebrew.yml
+++ b/.github/workflows/notify-homebrew.yml
@@ -35,11 +35,35 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Wait for npm package
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          PACKAGE: create-awesome-node-app
+        run: |
+          set -euo pipefail
+          attempts=24
+          delay=15
+          for attempt in $(seq 1 "$attempts"); do
+            if curl -sfL "https://registry.npmjs.org/${PACKAGE}/${VERSION}" \
+              | jq -e --arg v "$VERSION" '.version == $v' >/dev/null; then
+              echo "npm has ${PACKAGE}@${VERSION}"
+              exit 0
+            fi
+            echo "::warning::npm not ready for ${PACKAGE}@${VERSION} (attempt ${attempt}/${attempts}); retrying in ${delay}s"
+            sleep "$delay"
+          done
+          echo "::error::Timed out waiting for ${PACKAGE}@${VERSION} on npm"
+          exit 1
+
       - name: Dispatch repository event
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::HOMEBREW_TAP_TOKEN secret is not set" >&2
+            exit 1
+          fi
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -47,15 +47,34 @@ jobs:
         env:
           NEW_VERSION: ${{ steps.version.outputs.version }}
         run: |
+          set -euo pipefail
+          retry() {
+            local attempts="$1"
+            local delay="$2"
+            shift 2
+            for attempt in $(seq 1 "$attempts"); do
+              if "$@"; then
+                return 0
+              fi
+              if [ "$attempt" = "$attempts" ]; then
+                return 1
+              fi
+              echo "::warning::Attempt $attempt/$attempts failed: $*; retrying in ${delay}s" >&2
+              sleep "$delay"
+            done
+          }
+
           # Reset pkgver and pkgrel
           sed -i "s/^pkgver=.*/pkgver=${NEW_VERSION}/" PKGBUILD
           sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
 
-          # Fetch new npm tarball and compute sha256. -f makes curl exit
-          # non-zero on 4xx/5xx so we never silently hash an error page
-          # (e.g. tarball not yet propagated through npm's CDN).
+          # Fetch new npm tarball and compute sha256. Tags fire after npm
+          # publish, but the CDN can still lag — poll before hashing.
           URL="https://registry.npmjs.org/create-awesome-node-app/-/create-awesome-node-app-${NEW_VERSION}.tgz"
-          SHA=$(curl -sfL "$URL" | sha256sum | cut -d' ' -f1)
+          TMP="$(mktemp)"
+          retry 24 15 curl -sfL "$URL" -o "$TMP"
+          SHA=$(sha256sum "$TMP" | cut -d' ' -f1)
+          rm -f "$TMP"
           if [ -z "$SHA" ] || [ "$SHA" = "d41d8cd98f00b204e9800998ecf8427e" ]; then
             echo "::error::Failed to download or hash tarball at $URL" >&2
             exit 1

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -47,6 +47,26 @@ jobs:
             echo "minor=$MINOR"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Wait for npm package
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          PACKAGE: create-awesome-node-app
+        run: |
+          set -euo pipefail
+          attempts=24
+          delay=15
+          for attempt in $(seq 1 "$attempts"); do
+            if curl -sfL "https://registry.npmjs.org/${PACKAGE}/${VERSION}" \
+              | jq -e --arg v "$VERSION" '.version == $v' >/dev/null; then
+              echo "npm has ${PACKAGE}@${VERSION}"
+              exit 0
+            fi
+            echo "::warning::npm not ready for ${PACKAGE}@${VERSION} (attempt ${attempt}/${attempts}); retrying in ${delay}s"
+            sleep "$delay"
+          done
+          echo "::error::Timed out waiting for ${PACKAGE}@${VERSION} on npm"
+          exit 1
+
       - name: Set up QEMU
         # Required so buildx can cross-build linux/arm64 on the x86_64
         # ubuntu-latest runner.

--- a/docs/DISTRIBUTION_SETUP.md
+++ b/docs/DISTRIBUTION_SETUP.md
@@ -4,7 +4,7 @@
 (`create-awesome-node-app@X.Y.Z`):
 
 | Channel      | Workflow                               | Secret(s) needed                        |
-|--------------|----------------------------------------|-----------------------------------------|
+| ------------ | -------------------------------------- | --------------------------------------- |
 | **npm**      | `publish.yml`                          | (OIDC trusted publishing — no secret)   |
 | **Docker**   | `publish-docker.yml`                   | `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` |
 | **AUR**      | `publish-aur.yml`                      | `AUR_SSH_PRIVATE_KEY`, `AUR_REPO_TOKEN` |
@@ -173,5 +173,6 @@ Every subsequent release only requires:
 
 1. Merging the auto-generated **Version Packages** PR from Changesets.
 2. Nothing else — `publish.yml` publishes to npm, tags the release, and
-   the three tag-based workflows fan out to Docker Hub, AUR, and Homebrew
-   in parallel.
+   the three tag-based workflows fan out to Docker Hub, AUR, and Homebrew.
+   Each channel waits/retries on the npm registry so CDN lag after publish
+   does not fail the first attempt.


### PR DESCRIPTION
## Summary
- Poll npm registry before Docker image build and Homebrew notify
- Retry tarball download when hashing for AUR
- Document CDN wait behavior in DISTRIBUTION_SETUP

Tags already fire after npm publish; this hardens against registry lag on the first attempt.

## Test plan
- [ ] CI green
- [ ] Next release: Docker/AUR/Homebrew succeed without manual re-run

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release automation reliability by waiting for npm packages and tarballs to become available before publishing Docker, Homebrew, and AUR artifacts.
  * Added retry handling for temporary npm CDN propagation delays.
  * Added clearer workflow failures when required publishing credentials are missing or package availability times out.

* **Documentation**
  * Updated distribution setup guidance to describe npm registry waiting and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->