### PR TITLE
fix: bump core dep to ^0.7.5, carry --pin through non-interactive mode

### DIFF
--- a/.changeset/hip-mugs-draw.md
+++ b/.changeset/hip-mugs-draw.md
@@ -1,0 +1,28 @@
+---
+"create-awesome-node-app": patch
+---
+
+fix(cli): bump @create-node-app/core dependency to ^0.7.5
+
+The underlying fix in `@create-node-app/core@0.7.5` reads `package.json`
+with `readFileSync`+`JSON.parse` instead of `import()` with `{ type: "json" }`,
+which tsup strips when bundling, causing `ERR_IMPORT_ATTRIBUTE_MISSING` on
+Node >= 20.10. The error was silently caught, producing empty `package.json`
+data for every template and extension addon — meaning extension addon
+dependencies were silently dropped from the scaffolded project.
+
+The dependency range was pinned to `^0.7.4`, so npm/npx could resolve
+`0.7.4` (the buggy version) instead of `0.7.5` (the fixed version).
+Bumping to `^0.7.5` ensures users always get the fixed core package.
+
+fix(cli): carry --pin ref through to non-interactive option resolution
+
+The `--pin <ref>` value was stripped from the options object in `index.ts`
+before reaching `processNonInteractiveOptions`. The initial
+`templatesOrExtensions` array had pin applied, but `processNonInteractiveOptions`
+rebuilt the array from scratch using the raw (unpinned) option values,
+discarding the pin. This meant `--pin` had no effect in non-interactive mode.
+
+Now the pin value is carried through to the option resolver, which applies
+`?ref=<sha>` to template, addon, and extend URLs. `file://` URLs are still
+skipped (no git involved).

--- a/packages/create-awesome-node-app/package.json
+++ b/packages/create-awesome-node-app/package.json
@@ -82,7 +82,7 @@
     "test:src": "npm run test"
   },
   "dependencies": {
-    "@create-node-app/core": "^0.7.4",
+    "@create-node-app/core": "^0.7.5",
     "ci-info": "^4.4.0",
     "commander": "^15.0.0",
     "picocolors": "^1.1.1",
@@ -90,7 +90,7 @@
     "semver": "^7.8.5"
   },
   "devDependencies": {
-    "@create-node-app/core": "^0.7.4",
+    "@create-node-app/core": "^0.7.5",
     "@types/node": "^26.1.1",
     "@types/prompts": "^2.4.9",
     "@types/semver": "^7.5.8",

--- a/packages/create-awesome-node-app/src/index.ts
+++ b/packages/create-awesome-node-app/src/index.ts
@@ -218,9 +218,9 @@ const main = async () => {
 
   const latestVersion = await checkForLatestVersion("create-awesome-node-app");
   if (latestVersion && semver.lt(packageJson.version, latestVersion)) {
-    const strict =
-      opts.strictVersion || process.env.CNA_STRICT_VERSION === "1";
-    const message = `You are running \`create-awesome-node-app\` ${packageJson.version}, which is behind the latest release (${latestVersion}).\n\n` +
+    const strict = opts.strictVersion || process.env.CNA_STRICT_VERSION === "1";
+    const message =
+      `You are running \`create-awesome-node-app\` ${packageJson.version}, which is behind the latest release (${latestVersion}).\n\n` +
       "We recommend always using the latest version of create-awesome-node-app if possible.\n";
     if (strict) {
       console.error(pc.red(message));
@@ -271,27 +271,41 @@ const main = async () => {
 
   const pinRef = pin as string | undefined;
 
-  const templatesOrExtensions: TemplateOrExtension[] = [restOpts.template]
+  // Initial templatesOrExtensions includes template + extend + addons so all
+  // URLs get the --pin ref applied. The full resolution happens later in the
+  // options transform (processNonInteractiveOptions rebuilds the array from
+  // the raw option values below), so this is only a best-effort pass.
+  const templExtOrAddon = [restOpts.template]
     .concat(Array.isArray(restOpts.extend) ? restOpts.extend : [])
-    .filter(Boolean)
-    .reduce((acc, templateOrExtension) => {
-      if (!templateOrExtension) return acc;
-      let url = templateOrExtension;
-      // Apply --pin <ref> to URLs that don't already have a ?ref= parameter.
+    .concat(Array.isArray(restOpts.addons) ? restOpts.addons : [])
+    .filter(Boolean);
+  const templatesOrExtensions: TemplateOrExtension[] = templExtOrAddon.map(
+    (url) => {
       if (pinRef && !url.includes("?ref=") && !url.startsWith("file://")) {
         const separator = url.includes("?") ? "&" : "?";
         url = `${url}${separator}ref=${encodeURIComponent(pinRef)}`;
       }
-      return acc.concat({ url });
-    }, [] as TemplateOrExtension[]);
+      return { url };
+    },
+  );
 
   // `noCache` is consumed above (translates to env + refresh=always);
   // `cacheDir` similarly. Strip both from the rest spread so they don't
   // leak into the EJS context via the catch-all object.
-  const { cacheDir: _cacheDirFlag, strictVersion: _strictVersionFlag, pin: _pinFlag, ...scaffoldOpts } = restOpts;
+  const {
+    cacheDir: _cacheDirFlag,
+    strictVersion: _strictVersionFlag,
+    ...scaffoldOpts
+  } = restOpts;
   void noCache;
   void _cacheDirFlag;
   void _strictVersionFlag;
+
+  // Carry --pin through so processNonInteractiveOptions can also apply it
+  // when rebuilding templatesOrExtensions from slugs / catalog URLs.
+  if (pinRef) {
+    (scaffoldOpts as Record<string, unknown>).pin = pinRef;
+  }
 
   return createNodeApp(
     projectName,

--- a/packages/create-awesome-node-app/src/options.ts
+++ b/packages/create-awesome-node-app/src/options.ts
@@ -128,6 +128,17 @@ const isValidUrl = (url: string): boolean => {
 };
 
 /**
+ * Apply --pin <ref> to a URL (skip file:// and URLs with existing ?ref=).
+ */
+const applyPinRef = (url: string, pinRef?: string): string => {
+  if (pinRef && !url.includes("?ref=") && !url.startsWith("file://")) {
+    const separator = url.includes("?") ? "&" : "?";
+    url = `${url}${separator}ref=${encodeURIComponent(pinRef)}`;
+  }
+  return url;
+};
+
+/**
  * Process template and addons in non-interactive mode
  */
 const processNonInteractiveOptions = async (
@@ -143,6 +154,12 @@ const processNonInteractiveOptions = async (
   const templatesOrExtensions: TemplateOrExtension[] = [];
   let resolvedTemplateUrl: string | undefined;
 
+  // --pin is passed through from index.ts as a string
+  const pinRef =
+    typeof (options as Record<string, unknown>).pin === "string"
+      ? ((options as Record<string, unknown>).pin as string)
+      : undefined;
+
   // Handle cases where templates/extensions are not valid URLs
   if (options.template && !isValidUrl(options.template)) {
     const allTemplates = (
@@ -155,8 +172,10 @@ const processNonInteractiveOptions = async (
     );
     if (matchedTemplate) {
       // Add the template to templatesOrExtensions
-      templatesOrExtensions.push({ url: matchedTemplate.url });
-      resolvedTemplateUrl = matchedTemplate.url;
+      templatesOrExtensions.push({
+        url: applyPinRef(matchedTemplate.url, pinRef),
+      });
+      resolvedTemplateUrl = applyPinRef(matchedTemplate.url, pinRef);
 
       // Apply registry customOptions initial values (lowest priority — may be
       // overridden by cna.config.json or --set below)
@@ -174,8 +193,8 @@ const processNonInteractiveOptions = async (
     }
   } else if (options.template) {
     // If it's a valid URL, add it directly to templatesOrExtensions
-    templatesOrExtensions.push({ url: options.template });
-    resolvedTemplateUrl = options.template;
+    templatesOrExtensions.push({ url: applyPinRef(options.template, pinRef) });
+    resolvedTemplateUrl = applyPinRef(options.template, pinRef);
   }
 
   // Load cna.config.json from the resolved template directory.
@@ -226,7 +245,7 @@ const processNonInteractiveOptions = async (
         }
         return addon;
       })
-      .map((addon) => ({ url: addon }));
+      .map((addon) => ({ url: applyPinRef(addon, pinRef) }));
 
     templatesOrExtensions.push(...extensions);
   }
@@ -235,7 +254,7 @@ const processNonInteractiveOptions = async (
   if (options.extend && Array.isArray(options.extend)) {
     const additionalExtensions = options.extend
       .filter(Boolean)
-      .map((extension) => ({ url: extension }));
+      .map((extension) => ({ url: applyPinRef(extension, pinRef) }));
     templatesOrExtensions.push(...additionalExtensions);
   }
 


### PR DESCRIPTION
## Summary

Two fixes + a changeset for patch release.

## Changes

### `@create-node-app/core` dependency bumped
`^0.7.4` → `^0.7.5`. The fix in core`@0.7.5` reads `package.json` with `readFileSync`+ `JSON.parse` instead of `import()` with `{ type: "json" }`, which tsup strips when bundling, silently dropping all extension addon dependencies from the scaffolded project.

### `--pin` ref now works in non-interactive mode
The pin value was stripped from options before reaching `processNonInteractiveOptions`, which rebuilt `templatesOrExtensions` from scratch using raw (unpinned) values. Now pin is carried through and applied to template, addon, and extend URLs. `file://` URLs are skipped.

### Changeset
`hip-mugs-draw.md` for patch release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where template and addon dependencies could be omitted during project creation.
  - Fixed non-interactive `--pin <ref>` handling so templates, addons, and extensions use the specified reference.
  - Preserved local `file://` sources when applying pinned references.
  - Improved handling of pinned template, addon, and extension URLs across supported input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->