### PR TITLE
feat: test fixture infrastructure for offline catalog loading (#258)

### DIFF
--- a/.changeset/olive-taxis-lie.md
+++ b/.changeset/olive-taxis-lie.md
@@ -1,0 +1,21 @@
+---
+"create-awesome-node-app": minor
+---
+
+feat: test fixture infrastructure for offline catalog loading
+
+Adds a `fixtures/` directory with a minimal catalog, templates, and
+extensions for local testing without network access.
+
+- `fixtures/catalog/templates.json` — minimal catalog (2 templates, 1 extension, 2 categories)
+- `fixtures/templates/example-starter/` — template with `cna.config.json`, `template.json`, and scaffoldable files
+- `fixtures/extensions/example-addon/` — extension with additive template files
+
+The fixture mode is activated via:
+
+- `CNA_CATALOG_FIXTURE=1` env var
+- `--fixture [dir]` CLI flag (accepts optional fixture root path)
+
+When active, `getTemplateData()` loads from the local fixture catalog
+instead of fetching from GitHub, enabling fully offline development
+and testing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,4 +106,86 @@ npm run build -- --filter create-awesome-node-app
 
 ---
 
+---
+
+## 🧪 Testing with Fixtures
+
+The repository includes a `fixtures/` directory with a minimal catalog, templates, and extensions for offline testing without network access.
+
+### Fixture catalog
+
+```sh
+# Load template/extensions catalog from fixtures instead of GitHub
+CNA_CATALOG_FIXTURE=1 ./packages/create-awesome-node-app/index.js --list-templates
+CNA_CATALOG_FIXTURE=1 ./packages/create-awesome-node-app/index.js --list-addons
+```
+
+Or use the `--fixture` flag:
+
+```sh
+# Auto-detect fixture root (works in development checkout)
+./packages/create-awesome-node-app/index.js --fixture --list-templates
+
+# Explicit fixture root (useful when running from a different working directory)
+./packages/create-awesome-node-app/index.js --fixture /path/to/repo --list-templates
+```
+
+### Fixture structure
+
+```
+fixtures/
+  catalog/
+    templates.json         # Minimal catalog (2 templates, 1 extension, 2 categories)
+  templates/
+    example-starter/
+      cna.config.json      # Custom options config
+      template.json        # Dependencies/scripts metadata
+      template/            # Scaffoldable files (Lodash EJS)
+        README.md
+        package.json
+        [src]/index.ts.template
+  extensions/
+    example-addon/
+      package.json         # Extension dependencies
+      template/            # Additive scaffold files
+        jest.config.js
+        .gitignore.if-pnpm # Package-manager-conditional file
+```
+
+### Writing tests with fixtures
+
+Tests can use the fixture environment variables to avoid HTTP mocking:
+
+```typescript
+import { __resetTemplateDataCacheForTests } from "../templates.js";
+
+// In test setup:
+process.env.CNA_CATALOG_FIXTURE = "1";
+process.env.CNA_FIXTURE_DIR = path.resolve(__dirname, "../../../..");
+__resetTemplateDataCacheForTests();
+
+// After test:
+delete process.env.CNA_CATALOG_FIXTURE;
+delete process.env.CNA_FIXTURE_DIR;
+__resetTemplateDataCacheForTests();
+```
+
+For scaffolding tests that need real git repos, see the existing test pattern in
+`packages/create-node-app-core/tests/git.test.mts` which creates local bare git
+repositories via the `file://` protocol using `makeLocalBareGitRepo()`.
+
+---
+
+### Fixture API (source)
+
+| Export / Helper                      | Location       | Purpose                                                                          |
+| ------------------------------------ | -------------- | -------------------------------------------------------------------------------- |
+| `CNA_CATALOG_FIXTURE=1`              | env var        | Enables fixture mode in `getTemplateData()`                                      |
+| `CNA_FIXTURE_DIR=<path>`             | env var        | Override fixture root (default: auto-detect from `templates.ts`)                 |
+| `--fixture [dir]`                    | CLI flag       | Shorthand for setting `CNA_CATALOG_FIXTURE=1` (and optionally `CNA_FIXTURE_DIR`) |
+| `__setFixtureRootForTests(root)`     | `templates.ts` | Override fixture root programmatically in tests                                  |
+| `__resetTemplateDataCacheForTests()` | `templates.ts` | Clear the in-memory catalog cache                                                |
+
+---
+
 Again, **thank you** for helping make Create Awesome Node App better! 🚀

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -18,6 +18,7 @@ module.exports = [
       'packages/**/dist/**',
       '**/*.d.ts',
       'tools/danger/**',
+      'fixtures/**',
     ],
   },
   {

--- a/fixtures/catalog/templates.json
+++ b/fixtures/catalog/templates.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "./templates.schema.json",
+  "templates": [
+    {
+      "name": "Example Starter",
+      "slug": "example-starter",
+      "description": "A minimal Node.js project template for testing the CLI",
+      "url": "file:///fixtures/templates/example-starter",
+      "category": "example-framework",
+      "labels": ["node", "test", "example"],
+      "type": "example"
+    },
+    {
+      "name": "Vite Starter",
+      "slug": "vite-starter",
+      "description": "A Vite-powered frontend template for testing",
+      "url": "file:///fixtures/templates/vite-starter",
+      "category": "example-framework",
+      "labels": ["vite", "frontend", "test"],
+      "type": "example"
+    }
+  ],
+  "extensions": [
+    {
+      "name": "Example Addon",
+      "slug": "example-addon",
+      "description": "A minimal extension for testing addon behavior",
+      "url": "file:///fixtures/extensions/example-addon",
+      "category": "example-tooling",
+      "labels": ["example", "test"],
+      "type": "example"
+    }
+  ],
+  "categories": [
+    {
+      "slug": "example-framework",
+      "name": "Example Framework",
+      "description": "Example framework templates for CLI development and testing",
+      "details": "These templates are bundled with the CLI source to enable offline testing.",
+      "labels": ["example"]
+    },
+    {
+      "slug": "example-tooling",
+      "name": "Example Tooling",
+      "description": "Example tooling extensions for CLI development and testing",
+      "details": "These extensions are bundled with the CLI source to enable offline testing.",
+      "labels": ["example"]
+    }
+  ]
+}

--- a/fixtures/extensions/example-addon/package.json
+++ b/fixtures/extensions/example-addon/package.json
@@ -1,0 +1,9 @@
+{
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.0"
+  },
+  "scripts": {
+    "test": "jest"
+  }
+}

--- a/fixtures/extensions/example-addon/template/.gitignore.if-pnpm
+++ b/fixtures/extensions/example-addon/template/.gitignore.if-pnpm
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/fixtures/extensions/example-addon/template/jest.config.js
+++ b/fixtures/extensions/example-addon/template/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testMatch: ["**/__tests__/**/*.js"],
+};

--- a/fixtures/templates/example-starter/cna.config.json
+++ b/fixtures/templates/example-starter/cna.config.json
@@ -1,0 +1,21 @@
+{
+  "customOptions": [
+    {
+      "name": "srcDir",
+      "type": "select",
+      "message": "Source directory layout",
+      "initial": "src",
+      "choices": [
+        { "title": "src/", "value": "src" },
+        { "title": "lib/", "value": "lib" },
+        { "title": "Flat (no subdirectory)", "value": "." }
+      ]
+    },
+    {
+      "name": "authorName",
+      "type": "text",
+      "message": "Author name",
+      "initial": "Anonymous"
+    }
+  ]
+}

--- a/fixtures/templates/example-starter/template.json
+++ b/fixtures/templates/example-starter/template.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "express": "^4.21.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "scripts": {
+    "start": "node index.js",
+    "build": "tsc"
+  }
+}

--- a/fixtures/templates/example-starter/template/README.md
+++ b/fixtures/templates/example-starter/template/README.md
@@ -1,0 +1,14 @@
+# <%= projectName %>
+
+> Generated with [create-awesome-node-app](https://github.com/Create-Node-App/create-node-app)
+
+## Getting Started
+
+```bash
+<%= installCommand %>
+<%= runCommand %>
+```
+
+## Author
+
+<%= authorName %>

--- a/fixtures/templates/example-starter/template/[src]/index.ts.template
+++ b/fixtures/templates/example-starter/template/[src]/index.ts.template
@@ -1,0 +1,2 @@
+const greeting = "<%= projectName %>";
+console.log(`Hello from ${greeting}!`);

--- a/fixtures/templates/example-starter/template/package.json
+++ b/fixtures/templates/example-starter/template/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "<%= projectName %>",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "start": "node index.js"
+  }
+}

--- a/packages/create-awesome-node-app/src/index.ts
+++ b/packages/create-awesome-node-app/src/index.ts
@@ -155,6 +155,10 @@ const main = async () => {
       "disable the on-disk cache and always re-download templates (sets CNA_NO_CATALOG_CACHE=1 and forces refresh=always)",
     )
     .option(
+      "--fixture [dir]",
+      "load the template catalog from the local fixtures/ directory instead of the network (default: auto-detect from source location; also CNA_FIXTURE_DIR)",
+    )
+    .option(
       "--cache-dir <path>",
       "override the cache root (defaults to ~/.cache/cna; also CNA_CACHE_DIR)",
     )
@@ -231,6 +235,16 @@ const main = async () => {
     }
   }
 
+  // Translate --fixture into env vars for the template catalog loader.
+  // Must run BEFORE --list-templates / --list-addons so fixture mode is
+  // active when getTemplateData() is first called.
+  if (opts.fixture || process.env.CNA_CATALOG_FIXTURE === "1") {
+    process.env.CNA_CATALOG_FIXTURE = "1";
+    if (typeof opts.fixture === "string" && opts.fixture.length > 0) {
+      process.env.CNA_FIXTURE_DIR = opts.fixture;
+    }
+  }
+
   // Handle list templates flag
   if (opts.listTemplates) {
     await listTemplates();
@@ -257,7 +271,8 @@ const main = async () => {
   }
 
   // Extract package manager options directly from opts
-  const { useYarn, usePnpm, useBun, set, noCache, pin, ...restOpts } = opts;
+  const { useYarn, usePnpm, useBun, set, noCache, fixture, pin, ...restOpts } =
+    opts;
   const packageManager = useYarn
     ? "yarn"
     : usePnpm
@@ -298,6 +313,7 @@ const main = async () => {
     ...scaffoldOpts
   } = restOpts;
   void noCache;
+  void fixture;
   void _cacheDirFlag;
   void _strictVersionFlag;
 

--- a/packages/create-awesome-node-app/src/templates.ts
+++ b/packages/create-awesome-node-app/src/templates.ts
@@ -3,6 +3,7 @@ import { readFile } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
 import os from "os";
+import { fileURLToPath } from "url";
 
 const TEMPLATE_DATA_FILE_URL =
   "https://raw.githubusercontent.com/Create-Node-App/cna-templates/main/templates.json";
@@ -10,6 +11,90 @@ const TEMPLATE_DATA_FILE_URL =
 export const CNA_USER_AGENT = `create-awesome-node-app/0.9.9 (https://github.com/Create-Node-App/create-node-app)`;
 export const CNA_FETCH_TIMEOUT_MS = 10_000;
 export const CACHE_TTL_MS = 3600000; // 1 hour
+
+/**
+ * Resolve the fixtures root directory.
+ *
+ * Priority: CNA_FIXTURE_DIR env var → auto-detect from source location.
+ *
+ * Auto-detection walks up from the current module to `fixtures/` at the
+ * repo root. In CJS builds (where import.meta.url is unavailable) it falls
+ * back to checking process.cwd(), which works when the CLI is run from the
+ * repo root during development. For production use, set CNA_FIXTURE_DIR.
+ */
+const resolveFixtureRoot = (): string | null => {
+  const env = process.env.CNA_FIXTURE_DIR;
+  if (env && env.length > 0) {
+    return path.resolve(env);
+  }
+  // ESM: resolve relative to the source file path
+  try {
+    const sourceFile = fileURLToPath(import.meta.url);
+    const fromSource = path.resolve(sourceFile, "../../../../fixtures");
+    if (existsSync(fromSource)) {
+      return path.resolve(sourceFile, "../../../../fixtures");
+    }
+  } catch {
+    // CJS: import.meta.url is unavailable; fall through to cwd check
+  }
+  // CJS / fallback: check whether process.cwd() has a fixtures/ tree
+  const fromCwd = path.resolve(
+    process.cwd(),
+    "fixtures",
+    "catalog",
+    "templates.json",
+  );
+  if (existsSync(fromCwd)) {
+    return process.cwd();
+  }
+  return null;
+};
+
+let _fixtureRoot: string | null = null;
+const getFixtureRoot = (): string | null => {
+  if (_fixtureRoot === null) {
+    _fixtureRoot = resolveFixtureRoot();
+  }
+  return _fixtureRoot;
+};
+
+/**
+ * Override the fixture root (test helper).
+ */
+export const __setFixtureRootForTests = (root: string | null): void => {
+  _fixtureRoot = root;
+};
+
+const FORCE_FIXTURE = (): boolean => process.env.CNA_CATALOG_FIXTURE === "1";
+
+/**
+ * When in fixture mode, resolve a `file:///fixtures/…` URL to an absolute
+ * `file://` URL pointing at the on-disk fixture directory.
+ */
+const resolveFixtureUrl = (url: string): string => {
+  if (!url.startsWith("file:///fixtures/")) return url;
+  const root = getFixtureRoot();
+  if (!root) return url;
+  const relative = url.replace("file:///fixtures/", "");
+  const absolute = path.resolve(root, "fixtures", relative);
+  return `file://${absolute}`;
+};
+
+/**
+ * Resolve all fixture URLs in a loaded Templates object so downstream
+ * code (downloadRepository, etc.) receives real file:// paths.
+ */
+const resolveFixtureUrls = (data: Templates): Templates => ({
+  ...data,
+  templates: data.templates.map((t) => ({
+    ...t,
+    url: resolveFixtureUrl(t.url),
+  })),
+  extensions: data.extensions.map((e) => ({
+    ...e,
+    url: resolveFixtureUrl(e.url),
+  })),
+});
 
 export const getCatalogCacheDir = (): string => {
   const override = process.env.CNA_CACHE_DIR;
@@ -135,6 +220,35 @@ const isCacheFresh = (): boolean => {
 };
 
 export const getTemplateData = async (): Promise<Templates> => {
+  // Fixture mode: bypass network, load from local fixtures/ directory.
+  // This enables offline testing and development without network access.
+  if (FORCE_FIXTURE()) {
+    const root = getFixtureRoot();
+    if (!root) {
+      throw new Error(
+        "Fixture mode is enabled (CNA_CATALOG_FIXTURE=1) but the fixture root could not be resolved. " +
+          "Set CNA_FIXTURE_DIR to the repo root or run from a development checkout.",
+      );
+    }
+    const catalogPath = path.join(
+      root,
+      "fixtures",
+      "catalog",
+      "templates.json",
+    );
+    if (!existsSync(catalogPath)) {
+      throw new Error(
+        `Fixture catalog not found at ${catalogPath}. ` +
+          "Ensure CNA_FIXTURE_DIR points to the repo root containing fixtures/catalog/templates.json.",
+      );
+    }
+    const raw = await readFile(catalogPath, "utf8");
+    const data = resolveFixtureUrls(JSON.parse(raw) as Templates);
+    templateDataCache.data = data;
+    templateDataCache.timestamp = Date.now();
+    return data;
+  }
+
   if (isCacheFresh()) {
     return templateDataCache.data as Templates;
   }


### PR DESCRIPTION
## Summary

Adds a `fixtures/` directory with a minimal catalog, templates, and extensions for local testing of the CLI without network access. This infrastructure mirrors the approach used by [Create-Python-App](https://github.com/Create-Python-App/create-python-app/tree/main/fixtures) and enables fully offline development and CI testing.

## Changes

### New files
- **`fixtures/catalog/templates.json`** — minimal catalog with 2 templates, 1 extension, and 2 categories
- **`fixtures/templates/example-starter/`** — template with `cna.config.json` (custom options), `template.json` (deps), and scaffoldable files (`README.md`, `package.json`, `[src]/index.ts.template`)
- **`fixtures/extensions/example-addon/`** — extension with `package.json` (adds jest) and additive template files (`jest.config.js`, `.gitignore.if-pnpm`)

### Modified files
- **`packages/create-awesome-node-app/src/templates.ts`** — add `CNA_CATALOG_FIXTURE=1` env var support to `getTemplateData()`. When set, loads from the local fixture catalog instead of fetching from GitHub. Includes `resolveFixtureUrl()` to convert `file:///fixtures/…` relative URLs to absolute `file://` paths.
- **`packages/create-awesome-node-app/src/index.ts`** — add `--fixture [dir]` CLI flag that sets `CNA_CATALOG_FIXTURE=1` and optionally `CNA_FIXTURE_DIR`
- **`eslint.config.cjs`** — add `fixtures/**` to the ignore list
- **`CONTRIBUTING.md`** — document fixture usage, structure, and test patterns

### Exported test helpers
- `__setFixtureRootForTests(root)` — override fixture root programmatically in tests
- `__resetTemplateDataCacheForTests()` — clear the in-memory catalog cache

## Usage

```bash
# CLI
./packages/create-awesome-node-app/index.js --fixture --list-templates

# Env vars
CNA_CATALOG_FIXTURE=1 ./packages/create-awesome-node-app/index.js --list-templates
```

## Verification

- All 91 existing tests pass
- `--fixture --list-templates` shows fixture templates instead of the real catalog
- `getTemplateData()` returns fixture data with correctly resolved `file://` URLs

Closes #258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline fixture mode for loading template and addon catalogs without network access.
  * Added `--fixture [dir]` and `CNA_CATALOG_FIXTURE=1` options for selecting local fixtures.
  * Added sample templates, extensions, catalog data, and configurable project scaffolding.
* **Documentation**
  * Documented fixture usage, directory structure, configuration options, and testing guidance.
* **Bug Fixes**
  * Improved fixture path resolution and validation when loading local catalog data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->