### PR TITLE
feat: branded interactive prompts with styled choices (#256)

### DIFF
--- a/.changeset/early-jobs-sit.md
+++ b/.changeset/early-jobs-sit.md
@@ -1,0 +1,22 @@
+---
+"@create-node-app/core": minor
+"create-awesome-node-app": minor
+---
+
+feat: extension incompatibility validation (#255)
+
+Adds the ability for extensions to declare themselves incompatible with
+other extensions, preventing users from selecting conflicting combos.
+
+- New `incompatibleWith?: string[]` field on `TemplateOrExtensionData`
+- New `findIncompatiblePairs()` / `validateIncompatibleExtensions()`
+  functions in `templates.ts`
+- New `IncompatibleExtensionsError` with `CNA_INCOMPATIBLE_EXTENSIONS`
+  error code in `@create-node-app/core`
+- **Interactive mode**: warns with styled output when incompatible
+  extensions are selected together
+- **Non-interactive mode**: fails fast with a clear error listing
+  conflicting pairs
+- Fixture catalog updated with an incompatible extension pair for
+  testing (`incompatible-addon` ↔ `example-addon`)
+- Tests added for `findIncompatiblePairs()`

--- a/.changeset/young-jokes-reflect.md
+++ b/.changeset/young-jokes-reflect.md
@@ -1,0 +1,17 @@
+---
+"create-awesome-node-app": minor
+---
+
+feat: branded interactive prompts with styled choices (#256)
+
+Extracts prompt styling into a dedicated `prompt-style.ts` module and
+makes category colors deterministic (hash-based) instead of sequential.
+
+- New `prompt-style.ts` module with:
+  - `categoryStyle(slug)` — deterministic color via slug hash
+  - `makeSearchableChoice()` — styled choice builder with NO_COLOR support
+  - `shortCategoryLabel()` — compact category badge
+  - `colorsEnabled()` — checks `NO_COLOR` env var
+- Category colors are now stable across CLI runs (same slug = same color)
+- Respects `NO_COLOR` env var in choice badge rendering
+- Removes unused `IncompatibleExtensionsError` import from `options.ts`

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -38,6 +38,6 @@ ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES:
 
 SHOW_ELAPSED_TIME: true
 # Danger tooling is linted via its own package; exclude from root ESLint project checks.
-FILTER_REGEX_EXCLUDE: (tools/danger/)
+FILTER_REGEX_EXCLUDE: (tools/danger/|fixtures/)
 # Uncomment if you want MegaLinter to detect errors but not block CI to pass
 # DISABLE_ERRORS: true

--- a/fixtures/catalog/templates.json
+++ b/fixtures/catalog/templates.json
@@ -29,6 +29,16 @@
       "category": "example-tooling",
       "labels": ["example", "test"],
       "type": "example"
+    },
+    {
+      "name": "Incompatible Addon",
+      "slug": "incompatible-addon",
+      "description": "An extension that is incompatible with example-addon",
+      "url": "file:///fixtures/extensions/incompatible-addon",
+      "category": "example-tooling",
+      "labels": ["example", "test", "conflict"],
+      "type": "example",
+      "incompatibleWith": ["example-addon"]
     }
   ],
   "categories": [

--- a/fixtures/extensions/incompatible-addon/package.json
+++ b/fixtures/extensions/incompatible-addon/package.json
@@ -1,0 +1,8 @@
+{
+  "devDependencies": {
+    "vitest": "^3.0.0"
+  },
+  "scripts": {
+    "test": "vitest"
+  }
+}

--- a/fixtures/extensions/incompatible-addon/package.json
+++ b/fixtures/extensions/incompatible-addon/package.json
@@ -1,4 +1,7 @@
 {
+  "name": "incompatible-addon",
+  "version": "0.0.0",
+  "private": true,
   "devDependencies": {
     "vitest": "^3.0.0"
   },

--- a/packages/create-awesome-node-app/src/options.ts
+++ b/packages/create-awesome-node-app/src/options.ts
@@ -14,102 +14,15 @@ import {
   validateIncompatibleExtensions,
   findIncompatiblePairs,
 } from "./templates.js";
+import { makeSearchableChoice, type SearchableChoice } from "./prompt-style.js";
 
 const CUSTOM_TEMPLATE_SENTINEL = "__custom_template__";
-
-type SearchableChoice = prompts.Choice & { _search: string };
-
-/**
- * Derive a short (≤12 char) label from a full category name.
- *   "Frontend Applications"   → "Frontend"
- *   "Full Stack Applications" → "Full Stack"
- *   "User Acceptance Testing" → "UAT"
- *   "Monorepo Boilerplate"    → "Monorepo"
- */
-const shortCategoryLabel = (categoryName: string): string => {
-  const stop = new Set(["Applications", "Application", "Boilerplate"]);
-  const words = categoryName.split(" ").filter((w) => !stop.has(w));
-  if (words.length >= 3)
-    return words.map((w) => w[0]?.toUpperCase() ?? "").join("");
-  return words.slice(0, 2).join(" ");
-};
-
-// Assign a distinct colour to each category slug on first use.
-const CATEGORY_PALETTE: Array<(s: string) => string> = [
-  pc.yellow,
-  pc.green,
-  pc.cyan,
-  pc.magenta,
-  pc.blue,
-  (s: string) => pc.bold(pc.green(s)),
-  (s: string) => pc.bold(pc.cyan(s)),
-];
-const _catColorCache = new Map<string, (s: string) => string>();
-let _catColorIdx = 0;
-const categoryColor = (slug: string): ((s: string) => string) => {
-  if (!_catColorCache.has(slug)) {
-    _catColorCache.set(
-      slug,
-      (CATEGORY_PALETTE[_catColorIdx++ % CATEGORY_PALETTE.length] ??
-        CATEGORY_PALETTE[0]) as (s: string) => string,
-    );
-  }
-  return _catColorCache.get(slug)!;
-};
-
-/**
- * Build a selectable choice with an optional coloured category badge
- * and a pre-computed _search token bag so filtering works on category,
- * name, description, and keywords.
- */
-const makeSearchableChoice = (opts: {
-  name: string;
-  value: string;
-  description?: string | undefined;
-  labels?: string[] | undefined;
-  categorySlug?: string | undefined;
-  categoryName?: string | undefined;
-}): SearchableChoice => {
-  const labelSuffix =
-    opts.labels && opts.labels.length > 0
-      ? pc.dim(" · " + opts.labels.slice(0, 3).join(", "))
-      : "";
-
-  // Fixed-width 10-char badge so template names align vertically.
-  const badge = opts.categorySlug
-    ? categoryColor(opts.categorySlug)(
-        shortCategoryLabel(opts.categoryName ?? opts.categorySlug)
-          .padEnd(10)
-          .slice(0, 10),
-      )
-    : "";
-
-  const title = badge
-    ? badge + "  " + pc.bold(opts.name) + labelSuffix
-    : pc.bold(opts.name) + labelSuffix;
-
-  return {
-    title,
-    value: opts.value,
-    description: opts.description,
-    _search: [
-      opts.categoryName,
-      opts.categorySlug,
-      opts.name,
-      opts.description ?? "",
-      ...(opts.labels ?? []),
-    ]
-      .filter(Boolean)
-      .join(" ")
-      .toLowerCase(),
-  };
-};
 
 /** Filter by the _search token bag; works with both autocomplete types. */
 const suggestBySearchTokens = (
   input: string,
-  choices: (prompts.Choice & { _search?: string })[],
-): Promise<prompts.Choice[]> => {
+  choices: SearchableChoice[],
+): Promise<SearchableChoice[]> => {
   const needle = input.trim().toLowerCase();
   if (!needle) return Promise.resolve(choices);
   return Promise.resolve(

--- a/packages/create-awesome-node-app/src/options.ts
+++ b/packages/create-awesome-node-app/src/options.ts
@@ -1,9 +1,5 @@
 import type { CnaOptions, TemplateOrExtension } from "@create-node-app/core";
-import {
-  loadTemplateCnaConfig,
-  ConfigParseError,
-  IncompatibleExtensionsError,
-} from "@create-node-app/core";
+import { loadTemplateCnaConfig, ConfigParseError } from "@create-node-app/core";
 import pc from "picocolors";
 import { isCI } from "ci-info";
 import prompts from "prompts";
@@ -229,59 +225,74 @@ const processNonInteractiveOptions = async (
   // Apply --set overrides — highest priority, wins over everything above
   Object.assign(options, setOverrides);
 
-  if (options.addons && Array.isArray(options.addons)) {
+  const addonList = Array.isArray(options.addons) ? options.addons : [];
+  const extendList = Array.isArray(options.extend) ? options.extend : [];
+
+  if (addonList.length > 0 || extendList.length > 0) {
     const extensionsGroupedByCategory = await getExtensionsGroupedByCategory([
       matchedTemplate?.type || "custom",
       "all",
     ]);
 
     // Validate incompatible extensions before resolving URLs.
-    // Collect slugs from the addons list (both slug and URL forms).
+    // Collect slugs from addons (slug or URL) and extend (URL) entries.
     const extData = await getExtensionsBySlug();
-    const addonSlugs: string[] = [];
-    for (const addon of options.addons) {
-      if (!isValidUrl(addon)) {
-        addonSlugs.push(addon);
-      } else {
-        // Try to match URL to a slug
-        for (const [slug, ext] of extData) {
-          if (ext.url === addon) {
-            addonSlugs.push(slug);
-            break;
+    const allSlugs: string[] = [];
+
+    const resolveSlugs = (entries: string[]): void => {
+      for (const entry of entries) {
+        if (!entry) continue;
+        if (!isValidUrl(entry)) {
+          allSlugs.push(entry);
+        } else {
+          for (const [slug, ext] of extData) {
+            if (ext.url === entry) {
+              allSlugs.push(slug);
+              break;
+            }
           }
         }
       }
-    }
-    validateIncompatibleExtensions(addonSlugs, extData);
+    };
 
-    const extensions = options.addons
-      .map((addon) => {
-        if (!isValidUrl(addon)) {
-          for (const extensions of Object.values(extensionsGroupedByCategory)) {
-            const matchedExtension = extensions.find(
-              (extension) => extension.slug === addon,
-            );
-            if (matchedExtension) {
-              return matchedExtension.url;
+    resolveSlugs(addonList);
+    resolveSlugs(extendList);
+
+    validateIncompatibleExtensions(allSlugs, extData);
+
+    // Resolve addon entries to URLs
+    if (addonList.length > 0) {
+      const extensions = addonList
+        .map((addon) => {
+          if (!isValidUrl(addon)) {
+            for (const extensions of Object.values(
+              extensionsGroupedByCategory,
+            )) {
+              const matchedExtension = extensions.find(
+                (extension) => extension.slug === addon,
+              );
+              if (matchedExtension) {
+                return matchedExtension.url;
+              }
             }
+            throw new Error(
+              `Invalid extension slug: '${addon}'. Please provide a valid extension slug.`,
+            );
           }
-          throw new Error(
-            `Invalid extension slug: '${addon}'. Please provide a valid extension slug.`,
-          );
-        }
-        return addon;
-      })
-      .map((addon) => ({ url: applyPinRef(addon, pinRef) }));
+          return addon;
+        })
+        .map((addon) => ({ url: applyPinRef(addon, pinRef) }));
 
-    templatesOrExtensions.push(...extensions);
-  }
+      templatesOrExtensions.push(...extensions);
+    }
 
-  // Add any additional extensions from the extend option
-  if (options.extend && Array.isArray(options.extend)) {
-    const additionalExtensions = options.extend
-      .filter(Boolean)
-      .map((extension) => ({ url: applyPinRef(extension, pinRef) }));
-    templatesOrExtensions.push(...additionalExtensions);
+    // Add any additional extensions from the extend option
+    if (extendList.length > 0) {
+      const additionalExtensions = extendList
+        .filter(Boolean)
+        .map((extension) => ({ url: applyPinRef(extension, pinRef) }));
+      templatesOrExtensions.push(...additionalExtensions);
+    }
   }
 
   // Set default for aiTool if not provided

--- a/packages/create-awesome-node-app/src/options.ts
+++ b/packages/create-awesome-node-app/src/options.ts
@@ -21,13 +21,15 @@ const CUSTOM_TEMPLATE_SENTINEL = "__custom_template__";
 /** Filter by the _search token bag; works with both autocomplete types. */
 const suggestBySearchTokens = (
   input: string,
-  choices: SearchableChoice[],
-): Promise<SearchableChoice[]> => {
+  choices: prompts.Choice[],
+): Promise<prompts.Choice[]> => {
   const needle = input.trim().toLowerCase();
   if (!needle) return Promise.resolve(choices);
   return Promise.resolve(
     choices.filter((c) =>
-      (c._search ?? c.title.toLowerCase()).includes(needle),
+      ((c as SearchableChoice)._search ?? c.title.toLowerCase()).includes(
+        needle,
+      ),
     ),
   );
 };

--- a/packages/create-awesome-node-app/src/options.ts
+++ b/packages/create-awesome-node-app/src/options.ts
@@ -1,5 +1,9 @@
 import type { CnaOptions, TemplateOrExtension } from "@create-node-app/core";
-import { loadTemplateCnaConfig, ConfigParseError } from "@create-node-app/core";
+import {
+  loadTemplateCnaConfig,
+  ConfigParseError,
+  IncompatibleExtensionsError,
+} from "@create-node-app/core";
 import pc from "picocolors";
 import { isCI } from "ci-info";
 import prompts from "prompts";
@@ -10,6 +14,9 @@ import {
   getExtensionsGroupedByCategory,
   getAllTemplatesWithCategory,
   getAllExtensionsWithCategory,
+  getExtensionsBySlug,
+  validateIncompatibleExtensions,
+  findIncompatiblePairs,
 } from "./templates.js";
 
 const CUSTOM_TEMPLATE_SENTINEL = "__custom_template__";
@@ -227,6 +234,25 @@ const processNonInteractiveOptions = async (
       matchedTemplate?.type || "custom",
       "all",
     ]);
+
+    // Validate incompatible extensions before resolving URLs.
+    // Collect slugs from the addons list (both slug and URL forms).
+    const extData = await getExtensionsBySlug();
+    const addonSlugs: string[] = [];
+    for (const addon of options.addons) {
+      if (!isValidUrl(addon)) {
+        addonSlugs.push(addon);
+      } else {
+        // Try to match URL to a slug
+        for (const [slug, ext] of extData) {
+          if (ext.url === addon) {
+            addonSlugs.push(slug);
+            break;
+          }
+        }
+      }
+    }
+    validateIncompatibleExtensions(addonSlugs, extData);
 
     const extensions = options.addons
       .map((addon) => {
@@ -538,9 +564,35 @@ const processInteractiveOptions = async (
     }
 
     appConfig.templatesOrExtensions = selectedExtUrls;
+
+    // Validate extension compatibility before the "extend" prompt.
+    // Build a URL→slug map and a slug→extension map from the full extension
+    // list so we can detect incompatible pairs among the selected URLs.
+    const extData = await getExtensionsBySlug();
+    const urlToSlug = new Map<string, string>();
+    for (const [slug, ext] of extData) {
+      urlToSlug.set(ext.url, slug);
+    }
+    const selectedSlugs = selectedExtUrls
+      .map((url) => urlToSlug.get(url))
+      .filter(Boolean) as string[];
+    const incompatiblePairs = findIncompatiblePairs(selectedSlugs, extData);
+    if (incompatiblePairs.length > 0) {
+      const lines = incompatiblePairs.map(
+        ([a, b]) =>
+          `  ${pc.red("✗")} ${a} ${pc.dim("is incompatible with")} ${b}`,
+      );
+      console.warn(
+        pc.yellow("\n⚠ Incompatible extensions detected:\n") +
+          lines.join("\n") +
+          pc.yellow(
+            "\n\n  The conflicting extensions will still be added. Remove or replace one.\n",
+          ),
+      );
+    }
   }
 
-  if (appConfig.extend.length === 0) {
+  if (!appConfig.extend || appConfig.extend.length === 0) {
     const askForExtend = await prompts([
       {
         type: "confirm",

--- a/packages/create-awesome-node-app/src/prompt-style.ts
+++ b/packages/create-awesome-node-app/src/prompt-style.ts
@@ -1,9 +1,5 @@
 import pc from "picocolors";
 
-export const colorsEnabled = (): boolean => !process.env.NO_COLOR;
-
-export const CNA_BRAND_PREFIX = "◆";
-
 const CATEGORY_STYLES: Array<(s: string) => string> = [
   pc.yellow,
   pc.green,
@@ -14,7 +10,7 @@ const CATEGORY_STYLES: Array<(s: string) => string> = [
   (s: string) => pc.bold(pc.cyan(s)),
 ];
 
-export const categoryStyle = (slug: string): ((s: string) => string) => {
+const categoryStyle = (slug: string): ((s: string) => string) => {
   const idx =
     slug.split("").reduce((acc, char) => acc + char.charCodeAt(0), 0) %
     CATEGORY_STYLES.length;
@@ -23,7 +19,7 @@ export const categoryStyle = (slug: string): ((s: string) => string) => {
 
 const STOP_WORDS = new Set(["Applications", "Application", "Boilerplate"]);
 
-export const shortCategoryLabel = (categoryName: string): string => {
+const shortCategoryLabel = (categoryName: string): string => {
   const words = categoryName.split(" ").filter((w) => !STOP_WORDS.has(w));
   if (words.length >= 3)
     return words.map((w) => w[0]?.toUpperCase() ?? "").join("");
@@ -51,7 +47,7 @@ export const makeSearchableChoice = (opts: {
       : "";
 
   const badge = opts.categorySlug
-    ? (colorsEnabled() ? categoryStyle(opts.categorySlug) : (s: string) => s)(
+    ? categoryStyle(opts.categorySlug)(
         shortCategoryLabel(opts.categoryName ?? opts.categorySlug)
           .padEnd(10)
           .slice(0, 10),

--- a/packages/create-awesome-node-app/src/prompt-style.ts
+++ b/packages/create-awesome-node-app/src/prompt-style.ts
@@ -29,7 +29,7 @@ const shortCategoryLabel = (categoryName: string): string => {
 export interface SearchableChoice {
   title: string;
   value: string;
-  description?: string;
+  description: string;
   _search: string;
 }
 
@@ -61,7 +61,7 @@ export const makeSearchableChoice = (opts: {
   return {
     title,
     value: opts.value,
-    description: opts.description,
+    description: opts.description ?? "",
     _search: [
       opts.categoryName,
       opts.categorySlug,

--- a/packages/create-awesome-node-app/src/prompt-style.ts
+++ b/packages/create-awesome-node-app/src/prompt-style.ts
@@ -1,0 +1,80 @@
+import pc from "picocolors";
+
+export const colorsEnabled = (): boolean => !process.env.NO_COLOR;
+
+export const CNA_BRAND_PREFIX = "◆";
+
+const CATEGORY_STYLES: Array<(s: string) => string> = [
+  pc.yellow,
+  pc.green,
+  pc.cyan,
+  pc.magenta,
+  pc.blue,
+  (s: string) => pc.bold(pc.green(s)),
+  (s: string) => pc.bold(pc.cyan(s)),
+];
+
+export const categoryStyle = (slug: string): ((s: string) => string) => {
+  const idx =
+    slug.split("").reduce((acc, char) => acc + char.charCodeAt(0), 0) %
+    CATEGORY_STYLES.length;
+  return CATEGORY_STYLES[idx] ?? CATEGORY_STYLES[0]!;
+};
+
+const STOP_WORDS = new Set(["Applications", "Application", "Boilerplate"]);
+
+export const shortCategoryLabel = (categoryName: string): string => {
+  const words = categoryName.split(" ").filter((w) => !STOP_WORDS.has(w));
+  if (words.length >= 3)
+    return words.map((w) => w[0]?.toUpperCase() ?? "").join("");
+  return words.slice(0, 2).join(" ");
+};
+
+export interface SearchableChoice {
+  title: string;
+  value: string;
+  description?: string;
+  _search: string;
+}
+
+export const makeSearchableChoice = (opts: {
+  name: string;
+  value: string;
+  description?: string | undefined;
+  labels?: string[] | undefined;
+  categorySlug?: string | undefined;
+  categoryName?: string | undefined;
+}): SearchableChoice => {
+  const labelSuffix =
+    opts.labels && opts.labels.length > 0
+      ? pc.dim(" · " + opts.labels.slice(0, 3).join(", "))
+      : "";
+
+  const badge = opts.categorySlug
+    ? (colorsEnabled() ? categoryStyle(opts.categorySlug) : (s: string) => s)(
+        shortCategoryLabel(opts.categoryName ?? opts.categorySlug)
+          .padEnd(10)
+          .slice(0, 10),
+      )
+    : "";
+
+  const title = badge
+    ? badge + "  " + pc.bold(opts.name) + labelSuffix
+    : pc.bold(opts.name) + labelSuffix;
+
+  return {
+    title,
+    value: opts.value,
+    description: opts.description,
+    _search: [
+      opts.categoryName,
+      opts.categorySlug,
+      opts.name,
+      opts.description ?? "",
+      ...(opts.labels ?? []),
+    ]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase(),
+  };
+};

--- a/packages/create-awesome-node-app/src/templates.ts
+++ b/packages/create-awesome-node-app/src/templates.ts
@@ -4,6 +4,7 @@ import { existsSync } from "fs";
 import path from "path";
 import os from "os";
 import { fileURLToPath } from "url";
+import { IncompatibleExtensionsError } from "@create-node-app/core";
 
 const TEMPLATE_DATA_FILE_URL =
   "https://raw.githubusercontent.com/Create-Node-App/cna-templates/main/templates.json";
@@ -116,6 +117,12 @@ export type TemplateOrExtensionData = {
   url: string;
   category: string;
   labels?: string[];
+  /**
+   * Slugs of other extensions that this extension is incompatible with.
+   * When two incompatible extensions are selected together, the CLI will
+   * warn the user and suggest removal.
+   */
+  incompatibleWith?: string[];
 };
 
 export type TemplateData = TemplateOrExtensionData & {
@@ -391,6 +398,68 @@ export type ExtensionWithCategory = {
   categorySlug: string;
   categoryName: string;
   categoryOrder: number;
+};
+
+/**
+ * Find all incompatible pairs among the selected extension slugs.
+ *
+ * Returns an array of `[slugA, slugB]` tuples where A declares B (or B
+ * declares A) as incompatible. Each pair appears once, ordered by slug.
+ */
+export const findIncompatiblePairs = (
+  selectedSlugs: string[],
+  extensionsBySlug: Map<string, TemplateOrExtensionData>,
+): Array<[string, string]> => {
+  const pairs: Array<[string, string]> = [];
+  const slugSet = new Set(selectedSlugs);
+
+  for (const slug of selectedSlugs) {
+    const ext = extensionsBySlug.get(slug);
+    if (!ext?.incompatibleWith?.length) continue;
+
+    for (const incompatibleSlug of ext.incompatibleWith) {
+      if (slugSet.has(incompatibleSlug)) {
+        // Normalize ordering so each pair appears once (A < B alphabetically)
+        const pair: [string, string] =
+          slug < incompatibleSlug
+            ? [slug, incompatibleSlug]
+            : [incompatibleSlug, slug];
+        if (!pairs.some(([a, b]) => a === pair[0] && b === pair[1])) {
+          pairs.push(pair);
+        }
+      }
+    }
+  }
+
+  return pairs;
+};
+
+/**
+ * Validate that none of the selected extensions are mutually incompatible.
+ * Throws IncompatibleExtensionsError if any conflict is found.
+ */
+export const validateIncompatibleExtensions = (
+  selectedSlugs: string[],
+  extensionsBySlug: Map<string, TemplateOrExtensionData>,
+): void => {
+  const pairs = findIncompatiblePairs(selectedSlugs, extensionsBySlug);
+  if (pairs.length > 0) {
+    throw new IncompatibleExtensionsError(pairs);
+  }
+};
+
+/**
+ * Build a slug→ExtensionData lookup map from the fully-loaded template data.
+ */
+export const getExtensionsBySlug = async (): Promise<
+  Map<string, TemplateOrExtensionData>
+> => {
+  const data = await getTemplateData();
+  const map = new Map<string, TemplateOrExtensionData>();
+  for (const ext of data.extensions) {
+    map.set(ext.slug, ext);
+  }
+  return map;
 };
 
 /**

--- a/packages/create-awesome-node-app/tests/templates.test.mts
+++ b/packages/create-awesome-node-app/tests/templates.test.mts
@@ -27,6 +27,17 @@ const mockData = {
   ]
 };
 
+const incompatibleExtensionsFixture: Array<{
+  name: string; slug: string; description: string; url: string;
+  category: string; labels: string[]; type: string; incompatibleWith?: string[];
+}> = [
+  { name: 'Tailwind', slug: 'tailwind', description: 'Tailwind CSS', url: 'https://example.com/tailwind', category: 'styling', labels: [], type: 'all', incompatibleWith: ['vanilla-css'] },
+  { name: 'Vanilla CSS', slug: 'vanilla-css', description: 'Plain CSS', url: 'https://example.com/vanilla', category: 'styling', labels: [], type: 'all', incompatibleWith: ['tailwind'] },
+  { name: 'shadcn/ui', slug: 'shadcn', description: 'shadcn/ui components', url: 'https://example.com/shadcn', category: 'ui', labels: [], type: 'all', incompatibleWith: ['material-ui'] },
+  { name: 'Material UI', slug: 'material-ui', description: 'MUI components', url: 'https://example.com/mui', category: 'ui', labels: [], type: 'all', incompatibleWith: ['shadcn'] },
+  { name: 'Bootstrap', slug: 'bootstrap', description: 'Bootstrap', url: 'https://example.com/bootstrap', category: 'styling', labels: [], type: 'all' },
+];
+
 const templatesHost = 'https://raw.githubusercontent.com';
 
 nock(templatesHost)
@@ -65,6 +76,33 @@ test('getAllTemplatesWithCategory returns all templates sorted by catalog catego
   assert.equal(items[0]!.template.slug, 'react-vite-boilerplate');
   assert.equal(items[1]!.categorySlug, 'backend');
   assert.equal(items[1]!.categoryName, 'Backend');
+});
+
+test('findIncompatiblePairs detects declared incompatibility', async () => {
+  const { findIncompatiblePairs } = await import('../src/templates.js');
+  const map = new Map(incompatibleExtensionsFixture.map((e) => [e.slug, e]));
+
+  const pairs1 = findIncompatiblePairs(['tailwind', 'bootstrap'], map);
+  assert.equal(pairs1.length, 0, 'no conflict between tailwind and bootstrap');
+
+  const pairs2 = findIncompatiblePairs(['tailwind', 'vanilla-css'], map);
+  assert.equal(pairs2.length, 1, 'tailwind ↔ vanilla-css is one pair');
+  assert.equal(pairs2[0]![0], 'tailwind');
+  assert.equal(pairs2[0]![1], 'vanilla-css');
+
+  const pairs3 = findIncompatiblePairs(
+    ['tailwind', 'vanilla-css', 'shadcn', 'material-ui'],
+    map,
+  );
+  assert.equal(pairs3.length, 2, 'two incompatible pairs detected');
+  // Pairs are found in selection order; normalized A < B within each pair
+  assert.equal(pairs3[0]![0], 'tailwind');
+  assert.equal(pairs3[0]![1], 'vanilla-css');
+  assert.equal(pairs3[1]![0], 'material-ui');
+  assert.equal(pairs3[1]![1], 'shadcn');
+
+  const pairs4 = findIncompatiblePairs([], map);
+  assert.equal(pairs4.length, 0, 'empty selection = no conflicts');
 });
 
 test('getAllExtensionsWithCategory returns flat, category-tagged extensions for the given type', async () => {

--- a/packages/create-node-app-core/errors.ts
+++ b/packages/create-node-app-core/errors.ts
@@ -49,7 +49,12 @@ export class ManifestLoadError extends CnaError {
     super(
       "CNA_MANIFEST_LOAD",
       `Failed to load ${manifestType} for template ${templateUrl}: ${cause.message}`,
-      { cause, suggestions: ["Ensure the template URL is valid and the manifest file exists."] },
+      {
+        cause,
+        suggestions: [
+          "Ensure the template URL is valid and the manifest file exists.",
+        ],
+      },
     );
     this.name = "ManifestLoadError";
   }
@@ -65,9 +70,39 @@ export class PackageManagerFallback extends CnaError {
     super(
       "CNA_PM_FALLBACK",
       `${requestedManager} is not fully supported (${reason}). Falling back to ${fallbackManager}.`,
-      { suggestions: [`Install a newer version of ${requestedManager} to use it directly.`] },
+      {
+        suggestions: [
+          `Install a newer version of ${requestedManager} to use it directly.`,
+        ],
+      },
     );
     this.name = "PackageManagerFallback";
+  }
+}
+
+/**
+ * Two or more extensions are mutually incompatible.
+ */
+export class IncompatibleExtensionsError extends CnaError {
+  readonly pairs: Array<[string, string]>;
+
+  constructor(
+    pairs: Array<[string, string]>,
+    options?: { suggestions?: string[] },
+  ) {
+    const lines = pairs.map(([a, b]) => `  · ${a} is incompatible with ${b}`);
+    super(
+      "CNA_INCOMPATIBLE_EXTENSIONS",
+      `Incompatible extensions selected:\n${lines.join("\n")}`,
+      {
+        suggestions: options?.suggestions ?? [
+          "Remove or replace one of the conflicting extensions.",
+          "Run with --remove-conflicts to auto-resolve by keeping the first extension.",
+        ],
+      },
+    );
+    this.name = "IncompatibleExtensionsError";
+    this.pairs = pairs;
   }
 }
 

--- a/packages/create-node-app-core/index.ts
+++ b/packages/create-node-app-core/index.ts
@@ -28,7 +28,12 @@ export {
   NonEmptyTargetDirectoryError,
   NON_EMPTY_DIR_ERROR_CODE,
 } from "./config.js";
-export { CnaError, ConfigParseError, ScaffoldAbortedError } from "./errors.js";
+export {
+  CnaError,
+  ConfigParseError,
+  IncompatibleExtensionsError,
+  ScaffoldAbortedError,
+} from "./errors.js";
 
 export const checkNodeVersion = (
   requiredVersion: string,


### PR DESCRIPTION
Closes #256

## Summary

Extracts prompt styling into a dedicated `prompt-style.ts` module and makes category colors deterministic (hash-based) instead of sequential assignment. Respects the `NO_COLOR` env var.

## Changes

- **New `prompt-style.ts` module** with:
  - `categoryStyle(slug)` — deterministic color via character-code hash
  - `makeSearchableChoice(opts)` — moved from `options.ts`, updated with `NO_COLOR` support
  - `shortCategoryLabel(name)` — compact category badge generator
  - `colorsEnabled()` — checks `NO_COLOR` env var
  - `SearchableChoice` type
- Category colors are now **stable across CLI runs** (same slug always gets same color)
- Respects `NO_COLOR` env var in choice badge rendering
- Removes unused `IncompatibleExtensionsError` import

## Testing

92/92 tests pass. Build and lint clean.