### PR TITLE
ci: add markdownlint CI workflow

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,29 @@
+name: Markdown Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "31 1,12 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: markdownlint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  markdownlint:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Run markdownlint-cli2
+        uses: DavidAnson/markdownlint-cli2-action@v24
+        with:
+          globs: "**/*.md"

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Run markdownlint-cli2
         uses: DavidAnson/markdownlint-cli2-action@v24
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,7 @@ repositories via the `file://` protocol using `makeLocalBareGitRepo()`.
 ### Fixture API (source)
 
 | Export / Helper                      | Location       | Purpose                                                                          |
-| ------------------------------------ | -------------- | -------------------------------------------------------------------------------- |
+|--------------------------------------|----------------|----------------------------------------------------------------------------------|
 | `CNA_CATALOG_FIXTURE=1`              | env var        | Enables fixture mode in `getTemplateData()`                                      |
 | `CNA_FIXTURE_DIR=<path>`             | env var        | Override fixture root (default: auto-detect from `templates.ts`)                 |
 | `--fixture [dir]`                    | CLI flag       | Shorthand for setting `CNA_CATALOG_FIXTURE=1` (and optionally `CNA_FIXTURE_DIR`) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ Or use the `--fixture` flag:
 
 ### Fixture structure
 
-```
+```text
 fixtures/
   catalog/
     templates.json         # Minimal catalog (2 templates, 1 extension, 2 categories)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ More examples live in the [CLI package README](./packages/create-awesome-node-ap
 This is a Node 24+ monorepo managed with npm workspaces and [Turborepo](https://turbo.build/).
 
 | Path                                                                     | Purpose                                                                                                                                |
-| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+|--------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
 | [`packages/create-awesome-node-app`](./packages/create-awesome-node-app) | Main CLI package, Commander entrypoint, interactive wizard, catalog listing, and package metadata.                                     |
 | [`packages/create-node-app-core`](./packages/create-node-app-core)       | Scaffolding engine: resolves templates/extensions, copies files, applies template options, installs dependencies, and initializes git. |
 | [`packages/eslint-config-base`](./packages/eslint-config-base)           | Shared base ESLint flat config.                                                                                                        |
@@ -181,7 +181,7 @@ npx create-awesome-node-app local-app \
 ## Quality Checks
 
 | Command                 | What it validates                                          |
-| ----------------------- | ---------------------------------------------------------- |
+|-------------------------|------------------------------------------------------------|
 | `npm run build`         | Builds all packages through Turborepo.                     |
 | `npm run test`          | Runs package test tasks.                                   |
 | `npm run test:all`      | Runs all Node native test files under `packages/**/tests`. |
@@ -255,7 +255,7 @@ npx create-awesome-node-app --template react-vite-boilerplate --list-addons
 Common template slugs:
 
 | Slug                              | Description                                                                                           |
-| --------------------------------- | ----------------------------------------------------------------------------------------------------- |
+|-----------------------------------|-------------------------------------------------------------------------------------------------------|
 | `react-vite-boilerplate`          | React + Vite + TypeScript starter.                                                                    |
 | `nextjs-starter`                  | Production-ready Next.js starter.                                                                     |
 | `nextjs-saas-ai-starter`          | Multi-tenant SaaS starter with AI, Auth.js, Drizzle, PostgreSQL, Tailwind, shadcn/ui, RBAC, and i18n. |
@@ -270,7 +270,7 @@ Common template slugs:
 Common addon slugs:
 
 | Category       | Examples                                                                         |
-| -------------- | -------------------------------------------------------------------------------- |
+|----------------|----------------------------------------------------------------------------------|
 | UI             | `tailwind-css`, `material-ui`, `shadcn-ui`, `nextjs-shadcn`                      |
 | State and data | `zustand`, `jotai`, `tanstack-react-query`, `apollo-client`                      |
 | Backend and DB | `drizzle-orm-postgresql`, `drizzle-orm-sqlite`, `mongoose-orm-mongodb`           |

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ _Build starters quickly. Understand the repo quickly. Contribute confidently._
 ## 👥 Contributors
 
 <a href="https://github.com/Create-Node-App/create-node-app/contributors">
-  <img src="https://contrib.rocks/image?repo=Create-Node-App/create-node-app"/>
+  <img src="https://contrib.rocks/image?repo=Create-Node-App/create-node-app" alt="Contributors"/>
 </a>
 
 Made with [contributors-img](https://contrib.rocks).


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/markdownlint.yml` using `markdownlint-cli2-action`
- Runs on push/PR to `main`, scheduled cron (`31 1,12 * * *`), and `workflow_dispatch`
- Skips draft PRs and uses existing `.markdownlint.json` config

Closes #271

## Test plan

- [ ] Workflow YAML is valid
- [ ] CI passes on this PR (markdownlint job runs on non-draft PRs)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated Markdown linting for pushes and pull requests targeting the main branch.
  * Added scheduled Markdown quality checks.
  * Excludes draft pull requests from linting runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->