### PR TITLE
docs: add Architecture Decision Records

### DIFF
--- a/docs/adr/0001-monorepo-npm-workspaces-turborepo.md
+++ b/docs/adr/0001-monorepo-npm-workspaces-turborepo.md
@@ -1,0 +1,17 @@
+# ADR 0001: Monorepo with npm workspaces + Turborepo
+
+## Decision
+
+Organize the repository as an npm workspaces monorepo (`packages/*`) orchestrated by Turborepo.
+
+## Rationale
+
+- The CLI (`create-awesome-node-app`), shared core (`create-node-app-core`), and supporting packages ship together but publish independently via Changesets.
+- npm workspaces provide a single lockfile and hoisted devDependencies without extra tooling.
+- Turborepo caches build/lint/test tasks across packages and keeps CI fast.
+
+## Consequences
+
+- Root `package.json` owns shared dev tooling (ESLint, Prettier, Changesets, Turbo).
+- Package scripts are invoked via `turbo run <task>` from the root.
+- Version bumps and npm publishes are per-package through Changesets, not a single unified version.

--- a/docs/adr/0001-monorepo-npm-workspaces-turborepo.md
+++ b/docs/adr/0001-monorepo-npm-workspaces-turborepo.md
@@ -1,8 +1,18 @@
 # ADR 0001: Monorepo with npm workspaces + Turborepo
 
+## Context
+
+create-node-app ships a user-facing CLI, a reusable core library, and shared ESLint/TS configs that must stay version-aligned during development while publishing independently.
+
 ## Decision
 
 Organize the repository as an npm workspaces monorepo (`packages/*`) orchestrated by Turborepo.
+
+## Alternatives considered
+
+- **Single package repo**: simpler layout, but couples CLI and core release cadence and blocks sharing configs cleanly.
+- **pnpm / Yarn workspaces**: viable; npm workspaces were chosen to match the ecosystem default for consumers and CI (`npm ci`).
+- **No Turborepo**: plain npm scripts work at small scale; Turborepo was chosen for cached `build` / `lint` / `test` graphs as packages grow.
 
 ## Rationale
 

--- a/docs/adr/0002-commander-cli-framework.md
+++ b/docs/adr/0002-commander-cli-framework.md
@@ -1,0 +1,17 @@
+# ADR 0002: Commander as CLI framework
+
+## Decision
+
+Use [Commander.js](https://github.com/tj/commander.js) for the `create-awesome-node-app` CLI entrypoint, subcommands, flags, and help text.
+
+## Rationale
+
+- Mature, widely adopted Node.js CLI framework with declarative option parsing.
+- Supports nested subcommands (`cna cache list`, `cna cache doctor`, etc.) without custom parsing code.
+- Integrates cleanly with the bundled CJS/ESM dual build shipped to npm.
+
+## Consequences
+
+- Commander version must remain compatible with the CJS bundle (Commander 15+ is ESM-only; the published CLI pins a CJS-compatible release).
+- New flags and subcommands follow Commander conventions (`--flag`, positional args, built-in `--help`).
+- Alternative frameworks (yargs, oclif) were not adopted to keep the CLI dependency surface small.

--- a/docs/adr/0002-commander-cli-framework.md
+++ b/docs/adr/0002-commander-cli-framework.md
@@ -1,17 +1,26 @@
 # ADR 0002: Commander as CLI framework
 
+## Context
+
+The CLI needs nested subcommands (`cache list`, `cache doctor`), many flags, and stable `--help` output while remaining a thin wrapper over `@create-node-app/core`.
+
 ## Decision
 
 Use [Commander.js](https://github.com/tj/commander.js) for the `create-awesome-node-app` CLI entrypoint, subcommands, flags, and help text.
 
+## Alternatives considered
+
+- **yargs**: similar feature set; Commander’s declarative API and smaller surface won for this codebase.
+- **oclif**: stronger plugin model than needed for a single scaffolding binary.
+- **Hand-rolled argv parsing**: rejected to avoid maintenance cost for subcommands and help.
+
 ## Rationale
 
 - Mature, widely adopted Node.js CLI framework with declarative option parsing.
-- Supports nested subcommands (`cna cache list`, `cna cache doctor`, etc.) without custom parsing code.
+- Supports nested subcommands without custom parsing code.
 - Integrates cleanly with the bundled CJS/ESM dual build shipped to npm.
 
 ## Consequences
 
 - Commander version must remain compatible with the CJS bundle (Commander 15+ is ESM-only; the published CLI pins a CJS-compatible release).
 - New flags and subcommands follow Commander conventions (`--flag`, positional args, built-in `--help`).
-- Alternative frameworks (yargs, oclif) were not adopted to keep the CLI dependency surface small.

--- a/docs/adr/0003-git-template-checkout.md
+++ b/docs/adr/0003-git-template-checkout.md
@@ -1,0 +1,17 @@
+# ADR 0003: Git-based template checkout vs npm-published templates
+
+## Decision
+
+Resolve templates and extensions from **Git repositories** (GitHub HTTPS or local `file://` paths), not from npm packages published as scaffolds.
+
+## Rationale
+
+- Templates in `Create-Node-App/cna-templates` evolve frequently; git checkout gives exact commit/branch/ref control (`?ref=`, `--pin`).
+- `file://` URLs support local development and CI fixture mode without network access.
+- npm-published template tarballs would lag behind catalog updates and complicate private/enterprise starters.
+
+## Consequences
+
+- The CLI clones or copies from git (or file) into a working directory before scaffolding.
+- The catalog (`templates.json`) is fetched over HTTPS and cached separately from per-template git clones.
+- Users can point `--template` and `--addons` at any compatible GitHub repo or local path, not only the official catalog.

--- a/docs/adr/0003-git-template-checkout.md
+++ b/docs/adr/0003-git-template-checkout.md
@@ -1,17 +1,26 @@
 # ADR 0003: Git-based template checkout vs npm-published templates
 
+## Context
+
+Templates and extensions change often in `cna-templates`. Users also need private repos, pinned refs, and offline/local `file://` workflows.
+
 ## Decision
 
-Resolve templates and extensions from **Git repositories** (GitHub HTTPS or local `file://` paths), not from npm packages published as scaffolds.
+Resolve templates and extensions from **Git repositories** (GitHub HTTPS, SSH `git@`, or local `file://` paths), not from npm packages published as scaffolds.
+
+## Alternatives considered
+
+- **npm-published template tarballs**: simpler install UX, but lag catalog updates and complicate private/enterprise starters.
+- **HTTP zip downloads only**: lose git history, pin semantics, and incremental cache refresh.
 
 ## Rationale
 
 - Templates in `Create-Node-App/cna-templates` evolve frequently; git checkout gives exact commit/branch/ref control (`?ref=`, `--pin`).
 - `file://` URLs support local development and CI fixture mode without network access.
-- npm-published template tarballs would lag behind catalog updates and complicate private/enterprise starters.
+- npm-published template tarballs would lag behind catalog updates and complicate private starters.
 
 ## Consequences
 
 - The CLI clones or copies from git (or file) into a working directory before scaffolding.
 - The catalog (`templates.json`) is fetched over HTTPS and cached separately from per-template git clones.
-- Users can point `--template` and `--addons` at any compatible GitHub repo or local path, not only the official catalog.
+- Users can point `--template` and `--addons` at any compatible GitHub/SSH repo or local path, not only the official catalog.

--- a/docs/adr/0004-cache-design.md
+++ b/docs/adr/0004-cache-design.md
@@ -12,14 +12,14 @@ Cache cloned template/extension repos on disk under a configurable root (`~/.cac
 
 ## Key behaviors
 
-| Concern | Behavior |
-| --- | --- |
-| Cache root | `CNA_CACHE_DIR` or `--cache-dir`; working copy colocated under the same root |
-| Entry identity | Derived from normalized URL + branch/ref (base64-encoded path segment) |
-| Refresh mode | `always` \| `stale` (default) \| `manual` via `--refresh` or `CNA_REFRESH` |
-| Staleness threshold | `CNA_REFRESH_AFTER_HOURS` (default 24 h); stale entries trigger `git fetch` + merge |
-| Catalog cache | Separate TTL for `templates.json` (in-memory/disk catalog, distinct from git clones) |
-| Offline | `--offline` uses cache only; `--no-cache` bypasses on-disk cache entirely |
+| Concern             | Behavior                                                                             |
+|---------------------|--------------------------------------------------------------------------------------|
+| Cache root          | `CNA_CACHE_DIR` or `--cache-dir`; working copy colocated under the same root         |
+| Entry identity      | Derived from normalized URL + branch/ref (base64-encoded path segment)               |
+| Refresh mode        | `always` \| `stale` (default) \| `manual` via `--refresh` or `CNA_REFRESH`           |
+| Staleness threshold | `CNA_REFRESH_AFTER_HOURS` (default 24 h); stale entries trigger `git fetch` + merge  |
+| Catalog cache       | Separate TTL for `templates.json` (in-memory/disk catalog, distinct from git clones) |
+| Offline             | `--offline` uses cache only; `--no-cache` bypasses on-disk cache entirely            |
 
 ## Consequences
 

--- a/docs/adr/0004-cache-design.md
+++ b/docs/adr/0004-cache-design.md
@@ -22,14 +22,14 @@ Cache cloned template/extension repos on disk under a configurable root (`~/.cac
 
 ## Key behaviors
 
-| Concern | Behavior |
-| --- | --- |
-| Cache root | `CNA_CACHE_DIR` or `--cache-dir`; working copy colocated under the same root |
-| Entry identity | Derived from normalized URL + branch/ref (base64-encoded path segment) |
-| Refresh mode | `always` \| `stale` (default) \| `manual` via `--refresh` or `CNA_REFRESH` |
+| Concern             | Behavior                                                                            |
+|---------------------|-------------------------------------------------------------------------------------|
+| Cache root          | `CNA_CACHE_DIR` or `--cache-dir`; working copy colocated under the same root        |
+| Entry identity      | Derived from normalized URL + branch/ref (base64-encoded path segment)              |
+| Refresh mode        | `always` \| `stale` (default) \| `manual` via `--refresh` or `CNA_REFRESH`          |
 | Staleness threshold | `CNA_REFRESH_AFTER_HOURS` (default 24 h); stale entries trigger `git fetch` + merge |
-| Catalog cache | Separate TTL for `templates.json` (distinct from git clones) |
-| Offline | `--offline` uses cache only; `--no-cache` bypasses on-disk cache entirely |
+| Catalog cache       | Separate TTL for `templates.json` (distinct from git clones)                        |
+| Offline             | `--offline` uses cache only; `--no-cache` bypasses on-disk cache entirely           |
 
 ## Consequences
 

--- a/docs/adr/0004-cache-design.md
+++ b/docs/adr/0004-cache-design.md
@@ -1,0 +1,28 @@
+# ADR 0004: Cache design (freshness, staleness, keys)
+
+## Decision
+
+Cache cloned template/extension repos on disk under a configurable root (`~/.cache/cna` by default, overridable via `--cache-dir` / `CNA_CACHE_DIR`), with **stale-by-default** refresh semantics.
+
+## Rationale
+
+- Repeated scaffolds should not re-clone on every run.
+- Unconditional `git pull` on every invocation is slow and surprising; most users want cached content until it is old enough to refresh.
+- Explicit cache management (`cna cache list`, `clean`, `verify`, `outdated`, `update`, `doctor`) aids debugging and offline use.
+
+## Key behaviors
+
+| Concern | Behavior |
+| --- | --- |
+| Cache root | `CNA_CACHE_DIR` or `--cache-dir`; working copy colocated under the same root |
+| Entry identity | Derived from normalized URL + branch/ref (base64-encoded path segment) |
+| Refresh mode | `always` \| `stale` (default) \| `manual` via `--refresh` or `CNA_REFRESH` |
+| Staleness threshold | `CNA_REFRESH_AFTER_HOURS` (default 24 h); stale entries trigger `git fetch` + merge |
+| Catalog cache | Separate TTL for `templates.json` (in-memory/disk catalog, distinct from git clones) |
+| Offline | `--offline` uses cache only; `--no-cache` bypasses on-disk cache entirely |
+
+## Consequences
+
+- Default runs are fast and network-light; users opt into aggressive refresh with `--refresh always`.
+- Cache corruption is detectable via `cna cache verify` (`git fsck`).
+- CI and tests can isolate cache behavior with env vars and fixture directories.

--- a/docs/adr/0004-cache-design.md
+++ b/docs/adr/0004-cache-design.md
@@ -1,8 +1,18 @@
 # ADR 0004: Cache design (freshness, staleness, keys)
 
+## Context
+
+Scaffolding repeatedly clones the same template repos. Without a cache, every run is slow and network-heavy; with a naive always-pull cache, behavior is surprising.
+
 ## Decision
 
 Cache cloned template/extension repos on disk under a configurable root (`~/.cache/cna` by default, overridable via `--cache-dir` / `CNA_CACHE_DIR`), with **stale-by-default** refresh semantics.
+
+## Alternatives considered
+
+- **No cache (always clone)**: simplest correctness, unacceptable UX for iterative scaffolds.
+- **Always refresh**: keeps content fresh but defeats most of the performance benefit.
+- **Content-addressed npm-style store**: more complex than needed for git checkouts keyed by URL+ref.
 
 ## Rationale
 
@@ -12,14 +22,14 @@ Cache cloned template/extension repos on disk under a configurable root (`~/.cac
 
 ## Key behaviors
 
-| Concern             | Behavior                                                                             |
-|---------------------|--------------------------------------------------------------------------------------|
-| Cache root          | `CNA_CACHE_DIR` or `--cache-dir`; working copy colocated under the same root         |
-| Entry identity      | Derived from normalized URL + branch/ref (base64-encoded path segment)               |
-| Refresh mode        | `always` \| `stale` (default) \| `manual` via `--refresh` or `CNA_REFRESH`           |
-| Staleness threshold | `CNA_REFRESH_AFTER_HOURS` (default 24 h); stale entries trigger `git fetch` + merge  |
-| Catalog cache       | Separate TTL for `templates.json` (in-memory/disk catalog, distinct from git clones) |
-| Offline             | `--offline` uses cache only; `--no-cache` bypasses on-disk cache entirely            |
+| Concern | Behavior |
+| --- | --- |
+| Cache root | `CNA_CACHE_DIR` or `--cache-dir`; working copy colocated under the same root |
+| Entry identity | Derived from normalized URL + branch/ref (base64-encoded path segment) |
+| Refresh mode | `always` \| `stale` (default) \| `manual` via `--refresh` or `CNA_REFRESH` |
+| Staleness threshold | `CNA_REFRESH_AFTER_HOURS` (default 24 h); stale entries trigger `git fetch` + merge |
+| Catalog cache | Separate TTL for `templates.json` (distinct from git clones) |
+| Offline | `--offline` uses cache only; `--no-cache` bypasses on-disk cache entirely |
 
 ## Consequences
 

--- a/docs/adr/0005-extension-compatibility-validation.md
+++ b/docs/adr/0005-extension-compatibility-validation.md
@@ -1,8 +1,24 @@
 # ADR 0005: Extension compatibility validation
 
+## Context
+
+Some extensions are mutually exclusive. Users can select addons from the catalog (slugs) or pass arbitrary `--addons` / `--extend` URLs (see ADR 0003). Conflicts should fail before a partial project is written.
+
 ## Decision
 
-Extensions declare incompatible peers in catalog metadata (`incompatibleWith: string[]`). The CLI validates selected extensions **before scaffolding** and fails fast with a clear error when a conflict is detected.
+Extensions declare incompatible peers in **catalog metadata** (`incompatibleWith: string[]`). The CLI validates selected extensions **before scaffolding** and fails fast when a conflict is detected **for catalog-resolved extensions**.
+
+## Scope (catalog vs direct URLs)
+
+- Validation applies when an addon/extend value resolves to a **catalog slug** (or a URL that exactly matches a catalog entry URL), so `incompatibleWith` metadata is available.
+- Direct URLs that are **not** in the catalog are layered without catalog-based incompatibility checks. Operators of private/custom extensions own documenting conflicts; the CLI does not invent metadata for unknown URLs.
+- Future work may optionally fetch remote `cna.config.json` / catalog sidecars for URL addons; that is intentionally out of scope for this ADR.
+
+## Alternatives considered
+
+- **Validate only after merge**: simpler code, worse UX (partial trees).
+- **Hard-code conflicts in the CLI**: drifts from `cna-templates` and forks.
+- **Require catalog membership for all addons**: rejects legitimate private URL workflows from ADR 0003.
 
 ## Rationale
 
@@ -14,10 +30,11 @@ Extensions declare incompatible peers in catalog metadata (`incompatibleWith: st
 
 - `findIncompatiblePairs()` scans selected slugs against each extension's `incompatibleWith` list (symmetric).
 - `validateIncompatibleExtensions()` throws `IncompatibleExtensionsError` when any pair conflicts.
-- Validation runs after extension selection in interactive mode and when `--addons` is supplied non-interactively.
+- Validation runs after extension selection in interactive mode and when `--addons` is supplied non-interactively for catalog-resolved entries.
 
 ## Consequences
 
 - New extensions must document incompatibilities in catalog metadata, not only in README prose.
 - Template filtering (`getCompatibleExtensions`) hides extensions that conflict with the chosen template type.
 - Adding a new incompatible pair is a catalog change in `cna-templates`, not a CLI code change.
+- Direct non-catalog URLs remain supported; they skip catalog incompatibility validation by design.

--- a/docs/adr/0005-extension-compatibility-validation.md
+++ b/docs/adr/0005-extension-compatibility-validation.md
@@ -1,0 +1,23 @@
+# ADR 0005: Extension compatibility validation
+
+## Decision
+
+Extensions declare incompatible peers in catalog metadata (`incompatibleWith: string[]`). The CLI validates selected extensions **before scaffolding** and fails fast with a clear error when a conflict is detected.
+
+## Rationale
+
+- Some extension pairs are mutually exclusive (e.g. competing UI or state-management stacks).
+- Late failures during file merge produce partial projects and poor UX.
+- Declarative metadata in `templates.json` keeps rules centralized and reviewable in `cna-templates`.
+
+## Implementation
+
+- `findIncompatiblePairs()` scans selected slugs against each extension's `incompatibleWith` list (symmetric).
+- `validateIncompatibleExtensions()` throws `IncompatibleExtensionsError` when any pair conflicts.
+- Validation runs after extension selection in interactive mode and when `--addons` is supplied non-interactively.
+
+## Consequences
+
+- New extensions must document incompatibilities in catalog metadata, not only in README prose.
+- Template filtering (`getCompatibleExtensions`) hides extensions that conflict with the chosen template type.
+- Adding a new incompatible pair is a catalog change in `cna-templates`, not a CLI code change.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,13 @@
+# Architecture Decision Records
+
+Concise records of significant technical decisions in the create-node-app monorepo.
+
+| ADR | Title |
+| --- | --- |
+| [0001](./0001-monorepo-npm-workspaces-turborepo.md) | Monorepo with npm workspaces + Turborepo |
+| [0002](./0002-commander-cli-framework.md) | Commander as CLI framework |
+| [0003](./0003-git-template-checkout.md) | Git-based template checkout vs npm-published templates |
+| [0004](./0004-cache-design.md) | Cache design (freshness, staleness, keys) |
+| [0005](./0005-extension-compatibility-validation.md) | Extension compatibility validation |
+
+When adding a new ADR, use the next sequential number and link it here.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -2,12 +2,12 @@
 
 Concise records of significant technical decisions in the create-node-app monorepo.
 
-| ADR | Title |
-| --- | --- |
-| [0001](./0001-monorepo-npm-workspaces-turborepo.md) | Monorepo with npm workspaces + Turborepo |
-| [0002](./0002-commander-cli-framework.md) | Commander as CLI framework |
-| [0003](./0003-git-template-checkout.md) | Git-based template checkout vs npm-published templates |
-| [0004](./0004-cache-design.md) | Cache design (freshness, staleness, keys) |
-| [0005](./0005-extension-compatibility-validation.md) | Extension compatibility validation |
+| ADR                                                  | Title                                                  |
+|------------------------------------------------------|--------------------------------------------------------|
+| [0001](./0001-monorepo-npm-workspaces-turborepo.md)  | Monorepo with npm workspaces + Turborepo               |
+| [0002](./0002-commander-cli-framework.md)            | Commander as CLI framework                             |
+| [0003](./0003-git-template-checkout.md)              | Git-based template checkout vs npm-published templates |
+| [0004](./0004-cache-design.md)                       | Cache design (freshness, staleness, keys)              |
+| [0005](./0005-extension-compatibility-validation.md) | Extension compatibility validation                     |
 
 When adding a new ADR, use the next sequential number and link it here.


### PR DESCRIPTION
## Summary

- Adds `docs/adr/README.md` index
- ADR 0001: Monorepo with npm workspaces + Turborepo
- ADR 0002: Commander as CLI framework
- ADR 0003: Git-based template checkout vs npm-published templates
- ADR 0004: Cache design (freshness, staleness, keys)
- ADR 0005: Extension compatibility validation

Closes #273

## Test plan

- [ ] ADR index links resolve
- [ ] Content matches current CLI and monorepo behavior

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an Architecture Decision Records index covering the project’s key technical decisions.
  * Documented the monorepo structure, CLI framework selection, Git-based template sourcing, and template caching behavior.
  * Documented extension compatibility validation, including handling of incompatible combinations and catalog metadata requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->