### PR TITLE
feat(cli): style prompts with declarative formatted tokens

### DIFF
--- a/packages/create-awesome-node-app/src/prompt-style.ts
+++ b/packages/create-awesome-node-app/src/prompt-style.ts
@@ -1,6 +1,18 @@
 import pc from "picocolors";
 
-const CATEGORY_STYLES: Array<(s: string) => string> = [
+/**
+ * Declarative style tokens (CPA FormattedText parity).
+ * Tokens compose into a single ANSI string for the `prompts` library,
+ * which only accepts string titles — not token arrays.
+ */
+export type StyleFn = (s: string) => string;
+
+export interface StyleToken {
+  text: string;
+  style?: StyleFn;
+}
+
+const CATEGORY_STYLES: StyleFn[] = [
   pc.yellow,
   pc.green,
   pc.cyan,
@@ -10,7 +22,7 @@ const CATEGORY_STYLES: Array<(s: string) => string> = [
   (s: string) => pc.bold(pc.cyan(s)),
 ];
 
-const categoryStyle = (slug: string): ((s: string) => string) => {
+export const categoryStyle = (slug: string): StyleFn => {
   const idx =
     slug.split("").reduce((acc, char) => acc + char.charCodeAt(0), 0) %
     CATEGORY_STYLES.length;
@@ -19,12 +31,57 @@ const categoryStyle = (slug: string): ((s: string) => string) => {
 
 const STOP_WORDS = new Set(["Applications", "Application", "Boilerplate"]);
 
-const shortCategoryLabel = (categoryName: string): string => {
+export const shortCategoryLabel = (categoryName: string): string => {
   const words = categoryName.split(" ").filter((w) => !STOP_WORDS.has(w));
   if (words.length >= 3)
     return words.map((w) => w[0]?.toUpperCase() ?? "").join("");
   return words.slice(0, 2).join(" ");
 };
+
+export const colorsEnabled = (): boolean => {
+  if (process.env.NO_COLOR) return false;
+  if (process.env.CNA_COLOR === "0" || process.env.CNA_COLOR === "false") {
+    return false;
+  }
+  if (process.env.CNA_COLOR === "1" || process.env.CNA_COLOR === "true") {
+    return true;
+  }
+  return Boolean(process.stdout.isTTY);
+};
+
+/** Render styled tokens to a plain or ANSI string. */
+export const renderTokens = (tokens: StyleToken[]): string => {
+  if (!colorsEnabled()) {
+    return tokens.map((t) => t.text).join("");
+  }
+  return tokens.map((t) => (t.style ? t.style(t.text) : t.text)).join("");
+};
+
+/**
+ * Searchable title: keeps a plain `.search` / `.lower()` surface for filters
+ * while `toString()` returns the rendered (possibly styled) title.
+ */
+export class SearchableFormattedText {
+  readonly tokens: StyleToken[];
+  readonly search: string;
+
+  constructor(tokens: StyleToken[], search: string) {
+    this.tokens = tokens;
+    this.search = search;
+  }
+
+  toString(): string {
+    return renderTokens(this.tokens);
+  }
+
+  lower(): string {
+    return this.search.toLowerCase();
+  }
+
+  valueOf(): string {
+    return this.toString();
+  }
+}
 
 export interface SearchableChoice {
   title: string;
@@ -43,26 +100,31 @@ export const makeSearchableChoice = (opts: {
 }): SearchableChoice => {
   const labelSuffix =
     opts.labels && opts.labels.length > 0
-      ? pc.dim(" · " + opts.labels.slice(0, 3).join(", "))
+      ? " · " + opts.labels.slice(0, 3).join(", ")
       : "";
 
-  const badge = opts.categorySlug
-    ? categoryStyle(opts.categorySlug)(
-        shortCategoryLabel(opts.categoryName ?? opts.categorySlug)
-          .padEnd(10)
-          .slice(0, 10),
-      )
+  const badgeText = opts.categorySlug
+    ? shortCategoryLabel(opts.categoryName ?? opts.categorySlug)
+        .padEnd(10)
+        .slice(0, 10)
     : "";
 
-  const title = badge
-    ? badge + "  " + pc.bold(opts.name) + labelSuffix
-    : pc.bold(opts.name) + labelSuffix;
+  const tokens: StyleToken[] = [];
+  if (badgeText && opts.categorySlug) {
+    tokens.push({
+      text: badgeText,
+      style: categoryStyle(opts.categorySlug),
+    });
+    tokens.push({ text: "  " });
+  }
+  tokens.push({ text: opts.name, style: pc.bold });
+  if (labelSuffix) {
+    tokens.push({ text: labelSuffix, style: pc.dim });
+  }
 
-  return {
-    title,
-    value: opts.value,
-    description: opts.description ?? "",
-    _search: [
+  const formatted = new SearchableFormattedText(
+    tokens,
+    [
       opts.categoryName,
       opts.categorySlug,
       opts.name,
@@ -70,7 +132,14 @@ export const makeSearchableChoice = (opts: {
       ...(opts.labels ?? []),
     ]
       .filter(Boolean)
-      .join(" ")
-      .toLowerCase(),
+      .join(" "),
+  );
+
+  return {
+    // prompts expects a string; SearchableFormattedText stringifies on use
+    title: formatted.toString(),
+    value: opts.value,
+    description: opts.description ?? "",
+    _search: formatted.search.toLowerCase(),
   };
 };

--- a/packages/create-awesome-node-app/tests/prompt-style.test.mts
+++ b/packages/create-awesome-node-app/tests/prompt-style.test.mts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import pc from "picocolors";
+
+import {
+  SearchableFormattedText,
+  colorsEnabled,
+  makeSearchableChoice,
+  renderTokens,
+  shortCategoryLabel,
+} from "../src/prompt-style.js";
+
+test("shortCategoryLabel matches CPA/CNA badge rules", () => {
+  assert.equal(shortCategoryLabel("Backend Applications"), "Backend");
+  assert.equal(shortCategoryLabel("User Acceptance Testing"), "UAT");
+});
+
+test("renderTokens respects NO_COLOR", () => {
+  const previous = process.env.NO_COLOR;
+  process.env.NO_COLOR = "1";
+  try {
+    assert.equal(colorsEnabled(), false);
+    assert.equal(
+      renderTokens([
+        { text: "Backend  ", style: pc.yellow },
+        { text: "FastAPI", style: pc.bold },
+      ]),
+      "Backend  FastAPI",
+    );
+  } finally {
+    if (previous === undefined) delete process.env.NO_COLOR;
+    else process.env.NO_COLOR = previous;
+  }
+});
+
+test("SearchableFormattedText lower() uses search text", () => {
+  const title = new SearchableFormattedText(
+    [{ text: "X", style: pc.bold }],
+    "Backend FastAPI API",
+  );
+  assert.equal(title.lower(), "backend fastapi api");
+  assert.ok(title.toString().includes("X"));
+});
+
+test("makeSearchableChoice builds badge + name + labels", () => {
+  process.env.NO_COLOR = "1";
+  try {
+    const choice = makeSearchableChoice({
+      name: "FastAPI Starter",
+      value: "https://example.com",
+      description: "Async API",
+      labels: ["FastAPI", "API", "uv", "extra"],
+      categorySlug: "backend-applications",
+      categoryName: "Backend Applications",
+    });
+    assert.match(choice.title, /Backend/);
+    assert.match(choice.title, /FastAPI Starter/);
+    assert.match(choice.title, /· FastAPI, API, uv/);
+    assert.ok(choice._search.includes("backend"));
+    assert.equal(choice.description, "Async API");
+  } finally {
+    delete process.env.NO_COLOR;
+  }
+});


### PR DESCRIPTION
## Summary
- Add declarative `StyleToken` + `SearchableFormattedText` (CPA FormattedText parity)
- Rebuild `makeSearchableChoice` on `renderTokens` instead of ad-hoc ANSI concatenation
- Respect `NO_COLOR` and `CNA_COLOR`

## Test plan
- [x] `npx tsx --test packages/create-awesome-node-app/tests/prompt-style.test.mts`
- [ ] Interactive scaffold: category badges remain colored when TTY + colors on

Closes #270

Made with [Cursor](https://cursor.com)