### PR TITLE
docs(create-node-app-core): add JSDoc comments to core module functions

### DIFF
--- a/packages/create-node-app-core/config.ts
+++ b/packages/create-node-app-core/config.ts
@@ -3,7 +3,6 @@ import path from "path";
 import { getTemplateBaseDirPath } from "./paths.js";
 import { ConfigParseError } from "./errors.js";
 
-/** Configuration for custom CLI options in a CNA template. */
 export type CnaCustomOption = {
   name: string;
   type: string;
@@ -12,7 +11,6 @@ export type CnaCustomOption = {
   [key: string]: unknown;
 };
 
-/** Shape of the configuration parsed from a template's `cna.config.json` */
 export type CnaConfig = {
   customOptions?: CnaCustomOption[];
 };
@@ -33,7 +31,7 @@ export class NonEmptyTargetDirectoryError extends Error {
 
 /**
  * Asserts that the target directory is empty before scaffolding.
- * @param dirPath - Absolute path to the target directory.
+ * @param dirPath Absolute path to the target directory.
  * @throws {NonEmptyTargetDirectoryError} if the directory contains any entries other than `.DS_Store` or `Thumbs.db`.
  */
 export const assertDirectoryIsEmpty = (dirPath: string) => {

--- a/packages/create-node-app-core/config.ts
+++ b/packages/create-node-app-core/config.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { getTemplateBaseDirPath } from "./paths.js";
 import { ConfigParseError } from "./errors.js";
 
+/** Configuration for custom CLI options in a CNA template. */
 export type CnaCustomOption = {
   name: string;
   type: string;
@@ -11,12 +12,14 @@ export type CnaCustomOption = {
   [key: string]: unknown;
 };
 
+/** Shape of the configuration parsed from a template's `cna.config.json` */
 export type CnaConfig = {
   customOptions?: CnaCustomOption[];
 };
 
 export const NON_EMPTY_DIR_ERROR_CODE = "CNA_NON_EMPTY_TARGET_DIR";
 
+/** Error thrown when the scaffolding target directory is not empty. */
 export class NonEmptyTargetDirectoryError extends Error {
   readonly code = NON_EMPTY_DIR_ERROR_CODE;
 
@@ -28,6 +31,11 @@ export class NonEmptyTargetDirectoryError extends Error {
   }
 }
 
+/**
+ * Asserts that the target directory is empty before scaffolding.
+ * @param dirPath - Absolute path to the target directory.
+ * @throws {NonEmptyTargetDirectoryError} if the directory contains any entries other than `.DS_Store` or `Thumbs.db`.
+ */
 export const assertDirectoryIsEmpty = (dirPath: string) => {
   if (!fs.existsSync(dirPath)) {
     return;

--- a/packages/create-node-app-core/git.ts
+++ b/packages/create-node-app-core/git.ts
@@ -98,6 +98,14 @@ export type CacheMeta = {
   url?: string | undefined;
 };
 
+/**
+ * Reads the `.cna-meta.json` sidecar file from the given cache directory.
+ * Returns `null` if the file does not exist, cannot be parsed, or is missing
+ * the required `lastFetchedAt` field.
+ *
+ * @param cacheDir Absolute path to the cache directory containing `.cna-meta.json`
+ * @returns The parsed {@link CacheMeta} object, or `null` on failure
+ */
 export const readCacheMeta = (cacheDir: string): CacheMeta | null => {
   try {
     const raw = fs.readFileSync(metaSidecarPath(cacheDir), "utf8");
@@ -109,6 +117,14 @@ export const readCacheMeta = (cacheDir: string): CacheMeta | null => {
   }
 };
 
+/**
+ * Writes a {@link CacheMeta} object to `.cna-meta.json` inside the given cache directory.
+ * Creates the directory if it does not exist. Silently ignores write errors
+ * (failures are logged via the `cna:git:meta` debug channel).
+ *
+ * @param cacheDir Absolute path to the cache directory
+ * @param meta Metadata to persist
+ */
 export const writeCacheMeta = (cacheDir: string, meta: CacheMeta): void => {
   try {
     fs.mkdirSync(cacheDir, { recursive: true });
@@ -229,6 +245,9 @@ const copyTree = async (
 };
 
 /**
+ * Clones or refreshes a git repository into a local cache directory,
+ * then copies its contents to the target path.
+ *
  * @param opts options
  * @param opts.url The git repository url.
  * @param opts.targetId The target id. Default is `Buffer.from(`${gitUrl}@${branch}`).toString("base64")`

--- a/packages/create-node-app-core/index.ts
+++ b/packages/create-node-app-core/index.ts
@@ -37,7 +37,7 @@ export {
 
 /**
  * Checks that the current Node.js version satisfies the required semver range.
- * Print an error message and exits with code 1 if the check fails.
+ * Print an error message and exits if the check fails.
  * @param requiredVersion Semver range the current Node.js version must satisfy (e.g. `">=22.0.0"`).
  * @param packageName Name of the package or tool to display in the error message.
  */

--- a/packages/create-node-app-core/index.ts
+++ b/packages/create-node-app-core/index.ts
@@ -35,6 +35,12 @@ export {
   ScaffoldAbortedError,
 } from "./errors.js";
 
+/**
+ * Checks that the current Node.js version satisfies the required semver range.
+ * Print an error message and exits with code 1 if the check fails.
+ * @param requiredVersion Semver range the current Node.js version must satisfy (e.g. `">=22.0.0"`).
+ * @param packageName Name of the package or tool to display in the error message.
+ */
 export const checkNodeVersion = (
   requiredVersion: string,
   packageName: string,
@@ -55,6 +61,13 @@ const CNA_USER_AGENT = `create-node-app-core/${CNA_CORE_VERSION} (https://github
 
 export { CNA_USER_AGENT };
 
+/**
+ * Fetches the latest published version of a package from the npm registry.
+ * Falls back to `npm view <packageName> version` if the registry request fails.
+ * Returns `null` if both attempts fail.
+ * @param packageName The npm package name to look up (e.g. `"create-awesome-node-app"`).
+ * @returns The latest version string, or `null` if it could not be determined.
+ */
 export const checkForLatestVersion = async (packageName: string) => {
   try {
     const response = await fetch(
@@ -124,6 +137,14 @@ export type CnaOptions = {
 
 export type CnaOptionsTransform = (options: CnaOptions) => Promise<CnaOptions>;
 
+/**
+ * Entry point for scaffolding a new Node.js app.
+ * Validates that a project name was provided, applies option transforms
+ * and delegates to {@link createApp} to perform the actual scaffolding.
+ * @param programName  The CLI program name shown in usage/error messages.
+ * @param options Parsed CLI options passed from the program.
+ * @param transformOptions Async function to enrich or override options before scaffolding.
+ */
 export const createNodeApp = async (
   programName: string,
   options: CnaOptions,

--- a/packages/create-node-app-core/installer.ts
+++ b/packages/create-node-app-core/installer.ts
@@ -194,6 +194,29 @@ export function extractNameAndVersion(dependencyString: string) {
   }
 }
 
+/**
+ * Excutes the full app creation pipeline - scaffolding, dependency
+ * installation, and git initialization - inside the target project directory.
+ *
+ * @param options Run options (see {@link RunOptions})
+ * @param options.root Absolute path to the app directory
+ * @param options.appName App name (basename of the directory)
+ * @param options.originalDirectory CWD at the time `createApp` was called
+ * @param options.verbose? Enable verbose output from the package manager (default: `false`)
+ * @param options.useYarn? Use Yarn as the package manager (default: `false`)
+ * @param options.usePnpm? Use pnpm as the package manager (default: `false`)
+ * @param options.useBun? Use Bun as the package manager (default: `false`)
+ * @param options.templatesOrExtensions? Templates or extensions to apply
+ * @param options.dependencies? Production dependencies to install
+ * @param options.devDependencies? Development dependencies to intall
+ * @param options.installDependencies? Whether to install dependencies automatically (default: `false`)
+ * @param options.runCommand Script run command (e.g. `"npm run"`, `"yarn"`)
+ * @param options.installCommand Dependency install command (e.g. `"npm install"`)
+ * @param options.offline? Run in offline mode
+ * @param options.cacheDir? Path to the cache directory
+ * @param options.refresh?  Git cache refresh mode
+ * @param options.refreshAfterHours? Cache refresh interval in hours
+ */
 const run = async ({
   root,
   appName,
@@ -428,6 +451,27 @@ export type CreateAppOptions = {
   [key: string]: unknown;
 };
 
+/**
+ * Entry point for creating a new Node.js app.
+ *
+ * Creates a directory with the given name, resolves the package manager,
+ * then delegates to `run()` to copy template files, install dependencies,
+ * and initialize a git repository.
+ *
+ * @param options - App creation options (see {@link CreateAppOptions})
+ * @param options.name Name of the app (used as the directory name)
+ * @param options.verbose? Enable verbose output from the package manager (default: `false`)
+ * @param options.force? Proceed even if the target directory is not empty (default: `false`)
+ * @param options.packageManager? Package manager to use
+ * @param options.templatesOrExtensions? Template or extensions to apply
+ * @param options.installDependencies? Whether to install dependencies automatically (default: `true`)
+ * @param options.ignorePackage? Skip package.json merge logic (default: `false`)
+ * @param options.offline? Run in offline mode
+ * @param options.cacheDir? Path to the cache directory
+ * @param options.refresh? Git cache refresh mode
+ * @param options.refreshAfterHours? Cache refresh interval in hours
+ * @returns The return value of `run()` (`undefined` on success)
+ */
 export const createApp = async ({
   name,
   verbose = false,
@@ -504,7 +548,9 @@ export const createApp = async ({
   const originalDirectory = process.cwd();
   // Prepend \\?\ to bypass MAX_PATH (260 char) limit on Windows
   const chdirTarget =
-    process.platform === "win32" && root.length > 200 && !root.startsWith("\\\\?\\")
+    process.platform === "win32" &&
+    root.length > 200 &&
+    !root.startsWith("\\\\?\\")
       ? "\\\\?\\" + root
       : root;
   process.chdir(chdirTarget);

--- a/packages/create-node-app-core/installer.ts
+++ b/packages/create-node-app-core/installer.ts
@@ -195,27 +195,27 @@ export function extractNameAndVersion(dependencyString: string) {
 }
 
 /**
- * Excutes the full app creation pipeline - scaffolding, dependency
+ * Executes the full app creation pipeline - scaffolding, dependency
  * installation, and git initialization - inside the target project directory.
  *
  * @param options Run options (see {@link RunOptions})
  * @param options.root Absolute path to the app directory
  * @param options.appName App name (basename of the directory)
  * @param options.originalDirectory CWD at the time `createApp` was called
- * @param options.verbose? Enable verbose output from the package manager (default: `false`)
- * @param options.useYarn? Use Yarn as the package manager (default: `false`)
- * @param options.usePnpm? Use pnpm as the package manager (default: `false`)
- * @param options.useBun? Use Bun as the package manager (default: `false`)
- * @param options.templatesOrExtensions? Templates or extensions to apply
- * @param options.dependencies? Production dependencies to install
- * @param options.devDependencies? Development dependencies to intall
- * @param options.installDependencies? Whether to install dependencies automatically (default: `false`)
+ * @param [options.verbose] Enable verbose output from the package manager (default: `false`)
+ * @param [options.useYarn] Use Yarn as the package manager (default: `false`)
+ * @param [options.usePnpm] Use pnpm as the package manager (default: `false`)
+ * @param [options.useBun] Use Bun as the package manager (default: `false`)
+ * @param [options.templatesOrExtensions] Templates or extensions to apply
+ * @param [options.dependencies] Production dependencies to install
+ * @param [options.devDependencies] Development dependencies to install
+ * @param [options.installDependencies] Whether to install dependencies automatically (default: `true`)
  * @param options.runCommand Script run command (e.g. `"npm run"`, `"yarn"`)
  * @param options.installCommand Dependency install command (e.g. `"npm install"`)
- * @param options.offline? Run in offline mode
- * @param options.cacheDir? Path to the cache directory
- * @param options.refresh?  Git cache refresh mode
- * @param options.refreshAfterHours? Cache refresh interval in hours
+ * @param [options.offline] Run in offline mode
+ * @param [options.cacheDir] Path to the cache directory
+ * @param [options.refresh]  Git cache refresh mode
+ * @param [options.refreshAfterHours] Cache refresh interval in hours
  */
 const run = async ({
   root,
@@ -460,16 +460,16 @@ export type CreateAppOptions = {
  *
  * @param options - App creation options (see {@link CreateAppOptions})
  * @param options.name Name of the app (used as the directory name)
- * @param options.verbose? Enable verbose output from the package manager (default: `false`)
- * @param options.force? Proceed even if the target directory is not empty (default: `false`)
- * @param options.packageManager? Package manager to use
- * @param options.templatesOrExtensions? Template or extensions to apply
- * @param options.installDependencies? Whether to install dependencies automatically (default: `true`)
- * @param options.ignorePackage? Skip package.json merge logic (default: `false`)
- * @param options.offline? Run in offline mode
- * @param options.cacheDir? Path to the cache directory
- * @param options.refresh? Git cache refresh mode
- * @param options.refreshAfterHours? Cache refresh interval in hours
+ * @param [options.verbose] Enable verbose output from the package manager (default: `false`)
+ * @param [options.force] Proceed even if the target directory is not empty (default: `false`)
+ * @param [options.packageManager] Package manager to use
+ * @param [options.templatesOrExtensions] Template or extensions to apply
+ * @param [options.installDependencies] Whether to install dependencies automatically (default: `true`)
+ * @param [options.ignorePackage] Skip package.json merge logic (default: `false`)
+ * @param [options.offline] Run in offline mode
+ * @param [options.cacheDir] Path to the cache directory
+ * @param [options.refresh] Git cache refresh mode
+ * @param [options.refreshAfterHours] Cache refresh interval in hours
  * @returns The return value of `run()` (`undefined` on success)
  */
 export const createApp = async ({

--- a/packages/create-node-app-core/loaders.ts
+++ b/packages/create-node-app-core/loaders.ts
@@ -162,6 +162,11 @@ const batchedAppendFiles = async (
   await Promise.all(batchedPromises);
 };
 
+/**
+ * File loader that copies a file from the template directory to the project root as-is.
+ * Strips package-manager-specific suffixes (`.if-npm`, `.if-yarn`, etc.) and
+ * resolves `[src]/` path tokens to the configured source directory.
+ */
 const copyLoader: FileLoader =
   ({ root, templateDir, verbose, srcDir }) =>
   async ({ path }) => {
@@ -186,6 +191,11 @@ const copyLoader: FileLoader =
     await batchedCopyFiles(operations);
   };
 
+/**
+ * File loader that appends a template file's content to the destination file.
+ * Strips `.append` and package-manager-specific suffixes before resolving the destination path.
+ * Creates the destination file if it does not exist.
+ */
 const appendLoader: FileLoader =
   ({ root, templateDir, verbose, srcDir }) =>
   async ({ path }) => {
@@ -211,6 +221,12 @@ const appendLoader: FileLoader =
     await batchedAppendFiles(operations);
   };
 
+/**
+ * File loader that processes a file as a Lodash template before writing it to the project root.
+ * Interpolates variables such as `projectName`, `srcDir`, `runCommand`, `installCommand`,
+ * and any additional custom options.
+ * When `mode` includes `"append"`, the rendered content is appended rather than overwritten.
+ */
 const templateLoader: FileLoader =
   ({
     root,
@@ -260,6 +276,15 @@ const templateLoader: FileLoader =
     await batchedWriteFiles(operations);
   };
 
+/**
+ * Dispatches a single template file to the appropriate loader based on its file extension.
+ *
+ * Dispatch rules (checked against the file path):
+ * - `.template`                    → `templateLoader` (render + overwrite)
+ * - `.append`                      → `appendLoader`   (copy + append)
+ * - `.append.template` / `.template.append` → `templateLoader` (render + append)
+ * - anything else                  → `copyLoader`     (plain copy)
+ */
 const fileLoader: FileLoader =
   ({
     root,
@@ -334,6 +359,28 @@ export type LoadFilesOptions = {
   [key: string]: unknown;
 };
 
+/**
+ * Iterates over all provided templates/extensions, discovers their files,
+ * and applies the appropriate file loader to each entry in parallel.
+ * Throws if any file operation fails.
+ *
+ * @param options - See {@link LoadFilesOptions}
+ * @param options.root - Absolute path to the target project directory
+ * @param [options.templatesOrExtensions] - List of template/extension URLs to apply
+ * @param options.appName - App name used for template interpolation
+ * @param options.originalDirectory - CWD at the time the CLI was invoked
+ * @param options.verbose - Enable debug-level logging
+ * @param [options.useYarn] - Whether Yarn is the active package manager
+ * @param [options.usePnpm] - Whether pnpm is the active package manager
+ * @param [options.useBun] - Whether Bun is the active package manager
+ * @param [options.srcDir] - Source directory token replacement (default: `"src/"`)
+ * @param options.runCommand - Script run command passed to templates
+ * @param options.installCommand - Install command passed to templates
+ * @param [options.offline] - Resolve template directories in offline mode
+ * @param [options.cacheDir] - Custom cache directory for cloned templates
+ * @param [options.refresh] - Git cache refresh mode
+ * @param [options.refreshAfterHours] - Cache refresh interval in hours
+ */
 export const loadFiles = async ({
   root,
   templatesOrExtensions = [],
@@ -400,7 +447,9 @@ export const loadFiles = async ({
               ? [/\.if-yarn\./, /\.if-pnpm\./]
               : [/\.if-yarn\./, /\.if-pnpm\./, /\.if-bun\./];
         const shouldSkip = (p: string) =>
-          [...skipGlobs, ...skipManager].some((rgx) => rgx.test(p.toLowerCase()));
+          [...skipGlobs, ...skipManager].some((rgx) =>
+            rgx.test(p.toLowerCase()),
+          );
 
         for await (const entry of readdirp(templateDir, {
           type: "files",
@@ -455,7 +504,10 @@ export const loadFiles = async ({
     );
     if (rejected.length > 0) {
       const errorMessages = rejected
-        .map((r, i) => `  ${i + 1}. ${r.reason instanceof Error ? r.reason.message : String(r.reason)}`)
+        .map(
+          (r, i) =>
+            `  ${i + 1}. ${r.reason instanceof Error ? r.reason.message : String(r.reason)}`,
+        )
         .join("\n");
       throw new Error(
         `Failed to copy ${rejected.length} of ${results.length} file(s):\n${errorMessages}`,

--- a/packages/create-node-app-core/paths.ts
+++ b/packages/create-node-app-core/paths.ts
@@ -256,6 +256,19 @@ const solveTemplateOrExtensionPath = async (
   return { dir: gitData.dir, subdir: gitData.subdir, ignorePackage };
 };
 
+/**
+ * Resolves the absolute path to a named file (e.g. `package.json`) inside
+ * a template or extension directory.
+ *
+ * Throws if `name` is `"package.json"` and either the caller or the template
+ * itself has set `ignorePackage` to `true`.
+ *
+ * @param templateOrExtension Template or extension URL
+ * @param name? File name to resolve inside the template directory (default: `"package"`)
+ * @param ignorePackage? If `true`, throws then resolving `package.json` (default: `false`)
+ * @param opts Cache and network options (see {@link GetTemplatePathOptions})
+ * @returns Absolute path to the requested file
+ */
 export const getPackagePath = async (
   templateOrExtension: string,
   name = "package",
@@ -316,6 +329,17 @@ export const getTemplateBaseDirPath = async (
   }
 };
 
+/**
+ * Resolve the absolute path to the template files directory for a given
+ * template or extension URL.
+ *
+ * If a `template/` subdirectory exists inside the resolved path, that
+ * subdirectory is returned. Otherwise the resolved path itself is returned.
+ *
+ * @param templateOrExtensionUrl Template or extension URL to resolve
+ * @param opts? Cache and network options (see {@link GetTemplatePathOptions})
+ * @returns Absolute path to the directory containing the template files
+ */
 export const getTemplateDirPath = async (
   templateOrExtensionUrl: string,
   opts?: GetTemplatePathOptions,

--- a/packages/create-node-app-core/paths.ts
+++ b/packages/create-node-app-core/paths.ts
@@ -264,9 +264,9 @@ const solveTemplateOrExtensionPath = async (
  * itself has set `ignorePackage` to `true`.
  *
  * @param templateOrExtension Template or extension URL
- * @param name? File name to resolve inside the template directory (default: `"package"`)
- * @param ignorePackage? If `true`, throws then resolving `package.json` (default: `false`)
- * @param opts Cache and network options (see {@link GetTemplatePathOptions})
+ * @param [name] File name to resolve inside the template directory (default: `"package"`)
+ * @param [ignorePackage] If `true`, throws when resolving `package.json` (default: `false`)
+ * @param [opts] Cache and network options (see {@link GetTemplatePathOptions})
  * @returns Absolute path to the requested file
  */
 export const getPackagePath = async (
@@ -330,7 +330,7 @@ export const getTemplateBaseDirPath = async (
 };
 
 /**
- * Resolve the absolute path to the template files directory for a given
+ * Resolves the absolute path to the template files directory for a given
  * template or extension URL.
  *
  * If a `template/` subdirectory exists inside the resolved path, that


### PR DESCRIPTION
# What's this PR do?

Add JSDoc comments to core module functions in `packages/create-node-app-core`.
- [x] index.ts (createNodeApp, checkNodeVersion, checkForLatestVersion)
- [x] installer.ts (createApp, run)
- [x] loaders.ts (loadFiles, 4 loaders)
- [x] git.ts, paths.ts, config.ts

Fixes #234 

@ulises-jeremias

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive inline documentation for template configuration, project scaffolding, repository caching, version checks, file loading, path resolution, and app creation workflows.
  - Clarified expected parameters, return values, validation behavior, and error-handling semantics.
- **Style**
  - Reformatted several conditional expressions and error-message constructions for improved readability without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->