### PR TITLE
fix(security): eliminate ReDoS in dependency version-check regex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1111,24 +1111,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/config-array/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -1190,24 +1172,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
@@ -4287,12 +4251,6 @@
         "node": ">=22.12.0"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT"
-    },
     "node_modules/confbox": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
@@ -5031,22 +4989,6 @@
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
       }
     },
-    "node_modules/eslint-plugin-import/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -5104,22 +5046,6 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
-      }
-    },
-    "node_modules/eslint-plugin-jsx-a11y/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
@@ -5191,22 +5117,6 @@
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
-    "node_modules/eslint-plugin-react/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/eslint-plugin-react/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -5268,24 +5178,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
@@ -9238,10 +9130,10 @@
       }
     },
     "packages/create-awesome-node-app": {
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@create-node-app/core": "^0.8.0",
+        "@create-node-app/core": "^0.9.0",
         "ci-info": "^4.4.0",
         "commander": "^15.0.0",
         "picocolors": "^1.1.1",
@@ -9252,7 +9144,7 @@
         "create-awesome-node-app": "index.js"
       },
       "devDependencies": {
-        "@create-node-app/core": "^0.8.0",
+        "@create-node-app/core": "^0.9.0",
         "@types/node": "^26.1.1",
         "@types/prompts": "^2.4.9",
         "@types/semver": "^7.5.8",
@@ -9526,7 +9418,7 @@
     },
     "packages/create-node-app-core": {
       "name": "@create-node-app/core",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.6",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
   "overrides": {
     "@babel/runtime": "7.26.10",
     "esbuild": "^0.28.1",
-    "picomatch": "^4.0.5"
+    "picomatch": "^4.0.5",
+    "minimatch": {
+      "brace-expansion": ">=5.0.8"
+    }
   }
 }

--- a/packages/create-node-app-core/installer.ts
+++ b/packages/create-node-app-core/installer.ts
@@ -319,7 +319,11 @@ const run = async ({
       return deps.reduce(
         (dep, elem) => {
           const nextDep = dep;
-          if (/.+@(\^|~)?[0-9a-zA-Z-.]+$/.test(elem)) {
+          const lastAt = elem.lastIndexOf("@");
+          if (
+            lastAt > 0 &&
+            /^[\^~]?[0-9a-zA-Z.-]+$/.test(elem.slice(lastAt + 1))
+          ) {
             const { name, version } = extractNameAndVersion(elem);
             nextDep[name] = version;
           } else {


### PR DESCRIPTION
## Summary

Fixes CodeQL alert [js/polynomial-redos](https://github.com/Create-Node-App/create-node-app/security/code-scanning/27) in `packages/create-node-app-core/installer.ts`.

## Root cause

The regex `/.+@(\^|~)?[0-9a-zA-Z-.]+$/` has a polynomial backtracking problem:

- `.+` is greedy and **can match `@`**, so it competes with the literal `@` in the pattern
- On an adversarial input like `"aaa@aaa@aaa@"` (no valid version at the end), the engine backtracks O(n²) times before concluding there is no match

## Fix

Replace the single regex with two O(n) operations that mirror what `extractNameAndVersion` already does internally:

```typescript
// Before — polynomial ReDoS (O(n²) backtracking on pathological input):
if (/.+@(\^|~)?[0-9a-zA-Z-.]+$/.test(elem)) {

// After — linear:
const lastAt = elem.lastIndexOf("@");
if (lastAt > 0 && /^[\^~]?[0-9a-zA-Z.-]+$/.test(elem.slice(lastAt + 1))) {
```

1. `String#lastIndexOf('@')` locates the version separator in O(n) — same strategy as `extractNameAndVersion`
2. The second regex is anchored to the short version slice and has no overlapping quantifiers → no backtracking

All existing behaviors are preserved:
- Scoped packages with version (`@types/react@^18`) → split correctly ✓
- Bare scoped packages (`@types/react`) → `lastAt === 0`, skipped → `"*"` ✓
- Regular packages with version (`react@^18`) → split correctly ✓
- Bare regular packages (`react`) → `lastAt === -1`, skipped → `"*"` ✓

## Test plan

- [ ] All CI checks pass
- [ ] CodeQL scan re-runs and alert #27 is dismissed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency installation handling for packages with explicit versions, including scoped package names.
  * Added stricter validation to prevent incorrectly interpreted dependency versions.
* **Chores**
  * Updated dependency safeguards to require a compatible version of `brace-expansion`, helping maintain installation reliability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->