### PR TITLE
feat(cli): add --skip-install as alias for --no-install

### DIFF
--- a/packages/create-awesome-node-app/src/index.ts
+++ b/packages/create-awesome-node-app/src/index.ts
@@ -124,6 +124,7 @@ const main = async () => {
       "--no-install",
       "Generate package.json without installing dependencies",
     )
+    .option("--skip-install", "alias for --no-install")
     .option(
       "-t, --template <template>",
       "specify a template for the created project",
@@ -203,7 +204,13 @@ const main = async () => {
       projectName = providedProjectName || projectName;
     });
 
-  program.parse(process.argv);
+  // Rewrite --skip-install to --no-install before Commander parses argv,
+  // since Commander has no built-in alias support for negatable options.
+  program.parse(
+    process.argv.map((arg) =>
+      arg === "--skip-install" ? "--no-install" : arg,
+    ),
+  );
 
   const opts = program.opts();
 


### PR DESCRIPTION
# What's this PR do?

- [x] With --skip-install: files created, npm install not run, git still initialized

Rather than wiring up a separate option and merging the two flags manually,
`process.argv` is normalised before Commander parses it:

```ts
program.parse(
  process.argv.map((arg) =>
    arg === "--skip-install" ? "--no-install" : arg,
  ),
);
```
Fixed #242 

@ulises-jeremias




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--skip-install` as an alias for the existing `--no-install` command-line option.
  * Both options now provide the same behavior when creating a new app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->