### PR TITLE
feat(cli): add --skip-install as alias for --no-install

### DIFF
--- a/.changeset/skip-install-alias.md
+++ b/.changeset/skip-install-alias.md
@@ -1,0 +1,13 @@
+---
+"create-awesome-node-app": minor
+---
+
+feat(cli): add --skip-install as alias for --no-install (#290)
+
+Adds `--skip-install` as an intuitive alias for `--no-install`. Commander
+has no built-in alias support for negatable boolean options, so the CLI
+normalizes the alias to `--no-install` before parsing argv. The rewrite
+respects the `--` end-of-options boundary to avoid reinterpreting literal
+values passed as positional arguments.
+
+Contributed by @mynolog (Minho Lee).

--- a/packages/create-awesome-node-app/src/argv-aliases.ts
+++ b/packages/create-awesome-node-app/src/argv-aliases.ts
@@ -1,0 +1,31 @@
+/**
+ * Rewrite option aliases in argv before Commander parses it.
+ *
+ * Commander has no first-class support for aliases of negatable boolean
+ * options, so we normalize `--skip-install` to `--no-install` ourselves.
+ *
+ * The rewrite respects the `--` end-of-options boundary: tokens at or
+ * after the first `--` are passed through unchanged, so a literal
+ * `--skip-install` value given after `--` is preserved as a positional
+ * argument and never reinterpreted as the option.
+ *
+ * @param argv  The raw argv to normalize (typically `process.argv`).
+ * @returns     A new array with aliases rewritten before `--`.
+ */
+export const rewriteOptionAliases = (argv: readonly string[]): string[] => {
+  const out: string[] = [];
+  let pastEndOfOptions = false;
+  for (const arg of argv) {
+    if (arg === "--") {
+      pastEndOfOptions = true;
+      out.push(arg);
+      continue;
+    }
+    if (!pastEndOfOptions && arg === "--skip-install") {
+      out.push("--no-install");
+    } else {
+      out.push(arg);
+    }
+  }
+  return out;
+};

--- a/packages/create-awesome-node-app/src/index.ts
+++ b/packages/create-awesome-node-app/src/index.ts
@@ -124,6 +124,7 @@ const main = async () => {
       "--no-install",
       "Generate package.json without installing dependencies",
     )
+    .option("--skip-install", "alias for --no-install")
     .option(
       "-t, --template <template>",
       "specify a template for the created project",
@@ -203,7 +204,13 @@ const main = async () => {
       projectName = providedProjectName || projectName;
     });
 
-  program.parse(process.argv);
+  // Rewrite --skip-install to --no-install before Commander parses argv,
+  // since Commander has no built-in alias support for negatable options.
+  program.parse(
+    process.argv.map((arg) =>
+      arg === "--skip-install" ? "--no-install" : arg,
+    ),
+  );
 
   const opts = program.opts();
 

--- a/packages/create-awesome-node-app/src/index.ts
+++ b/packages/create-awesome-node-app/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from "@create-node-app/core";
 import { getCnaOptions } from "./options.js";
 import { parseSetOverrides } from "./set-overrides.js";
+import { rewriteOptionAliases } from "./argv-aliases.js";
 // NodeNext JSON import with import attributes
 import packageJson from "../package.json" with { type: "json" };
 import { listTemplates, listAddons } from "./list.js";
@@ -204,13 +205,11 @@ const main = async () => {
       projectName = providedProjectName || projectName;
     });
 
-  // Rewrite --skip-install to --no-install before Commander parses argv,
-  // since Commander has no built-in alias support for negatable options.
-  program.parse(
-    process.argv.map((arg) =>
-      arg === "--skip-install" ? "--no-install" : arg,
-    ),
-  );
+  // Rewrite option aliases before Commander parses argv. Commander has no
+  // built-in alias support for negatable options, so we normalize
+  // --skip-install to --no-install ourselves. The helper respects the `--`
+  // end-of-options boundary (see tests/argv-aliases.test.mts).
+  program.parse(rewriteOptionAliases(process.argv));
 
   const opts = program.opts();
 

--- a/packages/create-awesome-node-app/tests/argv-aliases.test.mts
+++ b/packages/create-awesome-node-app/tests/argv-aliases.test.mts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { rewriteOptionAliases } from "../src/argv-aliases.js";
+
+test("rewriteOptionAliases rewrites --skip-install before --", () => {
+  assert.deepEqual(
+    rewriteOptionAliases([
+      "node",
+      "create-awesome-node-app",
+      "--skip-install",
+      "my-app",
+    ]),
+    [
+      "node",
+      "create-awesome-node-app",
+      "--no-install",
+      "my-app",
+    ],
+  );
+});
+
+test("rewriteOptionAliases leaves --no-install untouched", () => {
+  assert.deepEqual(
+    rewriteOptionAliases([
+      "node",
+      "create-awesome-node-app",
+      "--no-install",
+      "my-app",
+    ]),
+    [
+      "node",
+      "create-awesome-node-app",
+      "--no-install",
+      "my-app",
+    ],
+  );
+});
+
+test("rewriteOptionAliases rewrites multiple --skip-install occurrences", () => {
+  assert.deepEqual(
+    rewriteOptionAliases([
+      "node",
+      "create-awesome-node-app",
+      "--skip-install",
+      "--verbose",
+      "--skip-install",
+    ]),
+    [
+      "node",
+      "create-awesome-node-app",
+      "--no-install",
+      "--verbose",
+      "--no-install",
+    ],
+  );
+});
+
+test("rewriteOptionAliases does not rewrite --skip-install after --", () => {
+  // A literal `--skip-install` value after the end-of-options marker must
+  // be preserved as a positional argument, not flipped to the boolean
+  // option. See CodeRabbit review on PR #290.
+  assert.deepEqual(
+    rewriteOptionAliases([
+      "node",
+      "create-awesome-node-app",
+      "--",
+      "--skip-install",
+    ]),
+    [
+      "node",
+      "create-awesome-node-app",
+      "--",
+      "--skip-install",
+    ],
+  );
+});
+
+test("rewriteOptionAliases only stops at the first --", () => {
+  assert.deepEqual(
+    rewriteOptionAliases([
+      "node",
+      "create-awesome-node-app",
+      "--",
+      "--skip-install",
+      "--",
+      "--skip-install",
+    ]),
+    [
+      "node",
+      "create-awesome-node-app",
+      "--",
+      "--skip-install",
+      "--",
+      "--skip-install",
+    ],
+  );
+});
+
+test("rewriteOptionAliases handles argv with no aliases unchanged", () => {
+  assert.deepEqual(
+    rewriteOptionAliases([
+      "node",
+      "create-awesome-node-app",
+      "--template",
+      "react-vite-boilerplate",
+      "my-app",
+    ]),
+    [
+      "node",
+      "create-awesome-node-app",
+      "--template",
+      "react-vite-boilerplate",
+      "my-app",
+    ],
+  );
+});
+
+test("rewriteOptionAliases returns a new array (does not mutate input)", () => {
+  const input = ["node", "--skip-install", "my-app"];
+  const result = rewriteOptionAliases(input);
+  assert.deepEqual(result, ["node", "--no-install", "my-app"]);
+  assert.deepEqual(input, ["node", "--skip-install", "my-app"]);
+});


### PR DESCRIPTION
Supersedes #290 — incorporates the original contribution by @mynolog plus the review fixes requested by CodeRabbit and Copilot.

## What

Adds `--skip-install` as an intuitive alias for `--no-install`. Commander has no built-in alias support for negatable boolean options, so the CLI normalizes the alias to `--no-install` before parsing argv.

## Changes vs. #290

- **CodeRabbit (end-of-options boundary)** — the alias rewrite now respects the `--` end-of-options marker, so a literal `--skip-install` value passed after `--` is preserved as a positional argument and never reinterpreted as the boolean option. Extracted into a pure, testable helper `src/argv-aliases.ts`.
- **Copilot (test coverage for the alias)** — added `tests/argv-aliases.test.mts` covering: rewrite before `--`, idempotency on `--no-install`, multiple occurrences, post-`--` preservation, no-mutation of input, and no-op when no alias is present. Prevents regressions if the rewrite is altered or removed.
- Added a changeset (`minor`) so the release flow publishes the new flag.

## Verification

- [x] `tsc --noEmit` passes (no new type errors)
- [x] `eslint src/argv-aliases.ts src/index.ts` passes (0 errors)
- [x] `tsx --test tests/argv-aliases.test.mts` — 7/7 pass
- [x] Self code-review completed

Closes #290.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `--skip-install` as an alternative to `--no-install` in the command-line interface.
  - Preserves literal `--skip-install` arguments entered after the `--` separator.

- **Bug Fixes**
  - Ensures the new option alias is interpreted consistently during command execution.

- **Tests**
  - Added coverage for alias conversion, repeated options, argument boundaries, and unchanged input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->