### PR TITLE
fix(core): resolve package.json inside template/ when base package.json is absent

### DIFF
--- a/.changeset/fix-template-package-fallback.md
+++ b/.changeset/fix-template-package-fallback.md
@@ -1,0 +1,8 @@
+---
+"@create-node-app/core": patch
+"create-awesome-node-app": patch
+---
+
+fix(core): resolve package.json inside template/ when base package.json is absent
+
+Support restructured templates where package.json lives only at templates/<name>/template/package.json (co-located with scaffold). getPackagePath now prefers template/package.json when it exists, allowing cna-templates to keep package.json only inside template/ without breaking file:// CI.

--- a/packages/create-node-app-core/paths.ts
+++ b/packages/create-node-app-core/paths.ts
@@ -295,10 +295,36 @@ export const getPackagePath = async (
     );
   }
 
+  // Support restructured templates: templates/<name>/{README.md,template/}
+  // where package.json lives inside template/ (user requested co-location).
+  // getTemplateDirPath already prefers template/ for scaffolding, but
+  // getPackagePath was still resolving to the base dir. Prefer
+  // template/package.json when it exists.
   if (subdir) {
-    return path.resolve(dir, subdir, name);
+    const baseCandidate = path.resolve(dir, subdir, name);
+    const templateCandidate = path.resolve(dir, subdir, "template", name);
+    try {
+      if (fs.existsSync(templateCandidate)) {
+        // If base also exists, prefer template/ for package.json (co-location).
+        // For other files (e.g. cna.config.json at base), keep base.
+        if (name === "package.json" || !fs.existsSync(baseCandidate)) {
+          return templateCandidate;
+        }
+      }
+    } catch {}
+    return baseCandidate;
   }
 
+  // No subdir: check for template/ at dir root (rare, but symmetric)
+  try {
+    const templateCandidate = path.resolve(dir, "template", name);
+    if (fs.existsSync(templateCandidate)) {
+      const baseCandidate = path.resolve(dir, name);
+      if (name === "package.json" || !fs.existsSync(baseCandidate)) {
+        return templateCandidate;
+      }
+    }
+  } catch {}
   return path.resolve(dir, name);
 };
 


### PR DESCRIPTION
Restructured templates (`templates/<name>/{README.md,template/}`) keep `package.json` only inside `template/` as requested.

- `getPackagePath` now prefers `template/package.json` when it exists (checked via `fs.existsSync`), matching `getTemplateDirPath`'s logic.
- Verified via `file://?subdir=templates/my-tpl` where base has no package.json but `template/package.json` exists → resolves to `template/package.json`.
- Tests: 54 pass, build success.

Closes #301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template file resolution for projects with nested `template/` directories.
  * Ensured the appropriate package configuration is selected when multiple versions are available.
  * Added fallback behavior so templates without nested directories continue to work correctly.
  * Improved resilience when filesystem lookup errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->