### PR TITLE
refactor(cli): improve Node version check error message

### DIFF
--- a/packages/create-node-app-core/index.ts
+++ b/packages/create-node-app-core/index.ts
@@ -46,14 +46,17 @@ export const checkNodeVersion = (
   packageName: string,
 ) => {
   if (!semver.satisfies(process.version, requiredVersion)) {
+    const minVersion = semver.minVersion(requiredVersion);
+    const majorVersion = minVersion?.major ?? "22";
+
     console.error(
       pc.red(
         `You are running Node ${process.version}.\n` +
-          `${packageName} requires Node v${requiredVersion.slice(2)}.\n` +
+          `${packageName} requires Node ${requiredVersion}.\n` +
           `To upgrade, choose one of these methods:\n` +
-          `nvm: nvm install --lts && nvm use --lts\n` +
-          `fnm: fnm install --lts && fnm use --lts\n` +
-          `volta: volta install node@lts\n` +
+          `nvm: nvm install ${majorVersion} && nvm use ${majorVersion}\n` +
+          `fnm: fnm install ${majorVersion} && fnm use ${majorVersion}\n` +
+          `volta: volta install node@${majorVersion}\n` +
           `Manual: https://nodejs.org/en/download/`,
       ),
     );

--- a/packages/create-node-app-core/index.ts
+++ b/packages/create-node-app-core/index.ts
@@ -49,8 +49,12 @@ export const checkNodeVersion = (
     console.error(
       pc.red(
         `You are running Node ${process.version}.\n` +
-          `${packageName} requires Node ${requiredVersion}.\n` +
-          "Please update your version of Node.",
+          `${packageName} requires Node v${requiredVersion.slice(2)}.\n` +
+          `To upgrade, choose one of these methods:\n` +
+          `nvm: nvm install --lts && nvm use --lts\n` +
+          `fnm: fnm install --lts && fnm use --lts\n` +
+          `volta: volta install node@lts\n` +
+          `Manual: https://nodejs.org/en/download/`,
       ),
     );
     process.exit(1);


### PR DESCRIPTION
# What's this PR do?

Improves the Node version check error message to be more actionable and helpful.

**Steps**
- [x] Improve to: show required vs detected version + upgrade instructions (fnm, nvm, manual).
- [x] packages/create-node-app-core/index.ts — checkNodeVersion()
- [x] Test with older Node version via fnm/nvm

**Before:**
```
You are running Node v20.18.0.
create-awesome-node-app requires Node >=22.0.0.
Please update your version of Node.
``` 

**After:**
```
You are running Node v20.18.0.
create-awesome-node-app requires Node >=22.0.0.
To upgrade, choose one of these methods:
nvm:   nvm install --lts && nvm use --lts
fnm:   fnm install --lts && fnm use --lts
volta: volta install node@lts
Manual: https://nodejs.org/en/download/
```

**Users now get:**
- Clear current, required version info
- Specific upgrade commands for each package manager (nvm, fnm, volta)
- Fallback manual installation link

Closes #235

@ulises-jeremias



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Node.js version error message with clearer upgrade instructions.
  * Added guidance for upgrading with nvm, fnm, Volta, or a manual download.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->