### PR TITLE
feat(cli): --json for list commands and --help examples

### DIFF
--- a/packages/create-awesome-node-app/src/index.ts
+++ b/packages/create-awesome-node-app/src/index.ts
@@ -154,6 +154,10 @@ const main = async () => {
     .option("--list-templates", "list all available templates")
     .option("--list-addons", "list all available addons")
     .option(
+      "--json",
+      "output --list-templates / --list-addons as JSON (for scripting)",
+    )
+    .option(
       "--set <assignments...>",
       "set a custom template option (format: key=value; quote values with spaces: --set 'projectName=My App' or --set 'projectName=My App' --set 'author=Jane Doe')",
     )
@@ -204,6 +208,19 @@ const main = async () => {
     .action((providedProjectName: string | undefined) => {
       projectName = providedProjectName || projectName;
     });
+
+  program.addHelpText(
+    "after",
+    `
+Examples:
+  $ create-awesome-node-app my-app --template react-vite-starter
+  $ create-awesome-node-app my-app --template nextjs-starter --addons nextjs-tailwindcss nextjs-shadcn
+  $ create-awesome-node-app --list-templates
+  $ create-awesome-node-app --list-templates --json
+  $ create-awesome-node-app --list-addons --template react-vite-starter --json
+  $ create-awesome-node-app my-app --template nestjs-starter --no-interactive
+  $ create-awesome-node-app my-app --set 'projectName=My App' --set 'srcDir=src'`,
+  );
 
   // Rewrite option aliases before Commander parses argv. Commander has no
   // built-in alias support for negatable options, so we normalize
@@ -290,7 +307,7 @@ const main = async () => {
 
   // Handle list templates flag
   if (opts.listTemplates) {
-    await listTemplates();
+    await listTemplates({ json: Boolean(opts.json) });
     return;
   }
 
@@ -298,6 +315,7 @@ const main = async () => {
   if (opts.listAddons) {
     await listAddons({
       templateSlug: opts.template,
+      json: Boolean(opts.json),
     });
     return;
   }

--- a/packages/create-awesome-node-app/src/list.ts
+++ b/packages/create-awesome-node-app/src/list.ts
@@ -9,10 +9,34 @@ import {
 } from "./templates.js";
 
 /**
- * List all available templates grouped by category
+ * List all available templates grouped by category.
+ * With `json: true` prints machine-readable JSON instead of colored text.
  */
-export const listTemplates = async () => {
+export const listTemplates = async ({ json = false }: { json?: boolean } = {}) => {
   const categories = await getTemplateCategories();
+
+  if (json) {
+    const groups = [];
+    for (const categorySlug of categories) {
+      const categoryData = await getCategoryData(categorySlug);
+      const templates = await getTemplatesForCategory(categorySlug);
+      groups.push({
+        slug: categorySlug,
+        name: categoryData?.name ?? categorySlug,
+        description: categoryData?.description ?? "",
+        templates: templates.map((template: TemplateData) => ({
+          name: template.name,
+          slug: template.slug,
+          description: template.description,
+          type: template.type,
+          labels: template.labels ?? [],
+          url: template.url,
+        })),
+      });
+    }
+    console.log(JSON.stringify({ templates: groups }, null, 2));
+    return;
+  }
 
   console.log(pc.bold(pc.blue("\nAvailable Templates:")));
 
@@ -47,9 +71,11 @@ export const listTemplates = async () => {
 export const listAddons = async ({
   templateSlug,
   templateType,
+  json = false,
 }: {
   templateSlug?: string;
   templateType?: string;
+  json?: boolean;
 }) => {
   // If templateSlug is provided but templateType is not, try to get the template type
   if (templateSlug && !templateType) {
@@ -61,6 +87,36 @@ export const listAddons = async ({
     : []; // empty array = show all
   const extensionsGroupedByCategory =
     await getExtensionsGroupedByCategory(types as any);
+
+  if (json) {
+    const groups = [];
+    for (const [categorySlug, extensions] of Object.entries(
+      extensionsGroupedByCategory,
+    )) {
+      const categoryData = await getCategoryData(categorySlug);
+      groups.push({
+        slug: categorySlug,
+        name: categoryData?.name ?? categorySlug,
+        description: categoryData?.description ?? "",
+        extensions: (extensions as ExtensionData[]).map((extension) => ({
+          name: extension.name,
+          slug: extension.slug,
+          description: extension.description,
+          type: extension.type,
+          labels: extension.labels ?? [],
+          url: extension.url,
+        })),
+      });
+    }
+    console.log(
+      JSON.stringify(
+        { addons: groups, ...(templateSlug ? { templateSlug } : {}) },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
 
   console.log(pc.bold(pc.blue("\nAvailable Addons:")));
 

--- a/packages/create-awesome-node-app/tests/list.test.mts
+++ b/packages/create-awesome-node-app/tests/list.test.mts
@@ -1,0 +1,77 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import nock from 'nock';
+
+import { listTemplates, listAddons } from '../src/list.js';
+
+const mockData = {
+  templates: [
+    { name: 'React Vite', slug: 'react-vite-boilerplate', description: 'React + Vite starter', url: 'https://example.com/react', category: 'frontend', labels: ['react'], type: 'react' },
+    { name: 'Nest API', slug: 'nest-api', description: 'Nest starter', url: 'https://example.com/nest', category: 'backend', labels: ['nest'], type: 'nest' }
+  ],
+  extensions: [
+    { name: 'ESLint', slug: 'eslint', description: 'ESLint preset', url: 'https://example.com/eslint', category: 'quality', labels: ['lint'], type: ['all'] },
+    { name: 'Jest', slug: 'jest', description: 'Jest setup', url: 'https://example.com/jest', category: 'testing', labels: ['test'], type: ['react', 'all'] }
+  ],
+  categories: [
+    { slug: 'frontend', name: 'Frontend', description: 'Frontend templates', details: '', labels: [] },
+    { slug: 'backend', name: 'Backend', description: 'Backend templates', details: '', labels: [] },
+    { slug: 'quality', name: 'Quality', description: 'Quality addons', details: '', labels: [] },
+    { slug: 'testing', name: 'Testing', description: 'Testing addons', details: '', labels: [] }
+  ]
+};
+
+nock('https://raw.githubusercontent.com')
+  .get(/\/Create-Node-App\/cna-templates\/main\/templates.json/)
+  .reply(200, mockData)
+  .persist();
+
+const captureLog = async (fn: () => Promise<void>): Promise<string[]> => {
+  const lines: string[] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => {
+    lines.push(args.map(String).join(' '));
+  };
+  try {
+    await fn();
+  } finally {
+    console.log = original;
+  }
+  return lines;
+};
+
+test('listTemplates --json prints parseable JSON grouped by category', async () => {
+  const lines = await captureLog(() => listTemplates({ json: true }));
+  const parsed = JSON.parse(lines.join('\n')) as {
+    templates: Array<{ slug: string; templates: Array<{ slug: string }> }>;
+  };
+  assert.ok(Array.isArray(parsed.templates));
+  const frontend = parsed.templates.find((g) => g.slug === 'frontend');
+  assert.ok(frontend, 'frontend group present');
+  assert.equal(frontend!.templates[0]!.slug, 'react-vite-boilerplate');
+});
+
+test('listTemplates human output still lists templates', async () => {
+  const lines = await captureLog(() => listTemplates());
+  assert.ok(lines.join('\n').includes('Available Templates'));
+  assert.ok(lines.join('\n').includes('react-vite-boilerplate'));
+});
+
+test('listAddons --json prints parseable JSON with extensions', async () => {
+  const lines = await captureLog(() => listAddons({ json: true }));
+  const parsed = JSON.parse(lines.join('\n')) as {
+    addons: Array<{ slug: string; extensions: Array<{ slug: string }> }>;
+  };
+  assert.ok(Array.isArray(parsed.addons));
+  const slugs = parsed.addons.flatMap((g) => g.extensions.map((e) => e.slug));
+  assert.ok(slugs.includes('eslint'));
+  assert.ok(slugs.includes('jest'));
+});
+
+test('listAddons --json echoes the template filter slug', async () => {
+  const lines = await captureLog(() =>
+    listAddons({ templateSlug: 'react-vite-boilerplate', json: true }),
+  );
+  const parsed = JSON.parse(lines.join('\n')) as { templateSlug?: string };
+  assert.equal(parsed.templateSlug, 'react-vite-boilerplate');
+});


### PR DESCRIPTION
Closes #230 (machine-readable --list-templates/--list-addons --json) and #229 (copy-pasteable Examples in --help).

Verified: 4 new tests pass, full package suite 58/58, tsc clean. Note: local eslint crashes on pristine tree too (broken minimatch under config-array in this env); bundled dist --help also fails on pristine tree here — both pre-existing, CI is the arbiter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--json` option to template and add-on listing commands.
  * JSON output includes structured category and item details.
  * Add-on results can include the selected template filter.

* **Documentation**
  * Updated command help examples to show JSON output usage.

* **Tests**
  * Added coverage for JSON and human-readable listing formats, including template filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->