### PR TITLE
docs: add CLI/template compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This is a Node 24+ monorepo managed with npm workspaces and [Turborepo](https://
 | [`packages/eslint-config-react`](./packages/eslint-config-react)         | React ESLint config extending the TypeScript preset.                                                                                   |
 | [`packages/eslint-config-next`](./packages/eslint-config-next)           | Next.js ESLint config extending the TypeScript preset.                                                                                 |
 | [`packages/tsconfig`](./packages/tsconfig)                               | Shared TypeScript base configurations.                                                                                                 |
-| [`docs/`](./docs)                                                        | Brand guidance, troubleshooting, and migration notes.                                                                                  |
+| [`docs/`](./docs)                                                        | Brand guidance, troubleshooting, migration notes, and [compatibility](./docs/COMPATIBILITY.md).                                         |
 | [`.github/workflows`](./.github/workflows)                               | CI for tests, lint, typecheck, shellcheck, markdown, and release automation.                                                           |
 
 Template and extension data is maintained in [`Create-Node-App/cna-templates`](https://github.com/Create-Node-App/cna-templates). This repo consumes that catalog remotely.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ More examples live in the [CLI package README](./packages/create-awesome-node-ap
 This is a Node 24+ monorepo managed with npm workspaces and [Turborepo](https://turbo.build/).
 
 | Path                                                                     | Purpose                                                                                                                                |
-| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+|--------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
 | [`packages/create-awesome-node-app`](./packages/create-awesome-node-app) | Main CLI package, Commander entrypoint, interactive wizard, catalog listing, and package metadata.                                     |
 | [`packages/create-node-app-core`](./packages/create-node-app-core)       | Scaffolding engine: resolves templates/extensions, copies files, applies template options, installs dependencies, and initializes git. |
 | [`packages/eslint-config-base`](./packages/eslint-config-base)           | Shared base ESLint flat config.                                                                                                        |
@@ -74,7 +74,7 @@ This is a Node 24+ monorepo managed with npm workspaces and [Turborepo](https://
 | [`packages/eslint-config-react`](./packages/eslint-config-react)         | React ESLint config extending the TypeScript preset.                                                                                   |
 | [`packages/eslint-config-next`](./packages/eslint-config-next)           | Next.js ESLint config extending the TypeScript preset.                                                                                 |
 | [`packages/tsconfig`](./packages/tsconfig)                               | Shared TypeScript base configurations.                                                                                                 |
-| [`docs/`](./docs)                                                        | Brand guidance, troubleshooting, migration notes, and [compatibility](./docs/COMPATIBILITY.md).                                         |
+| [`docs/`](./docs)                                                        | Brand guidance, troubleshooting, migration notes, and [compatibility](./docs/COMPATIBILITY.md).                                        |
 | [`.github/workflows`](./.github/workflows)                               | CI for tests, lint, typecheck, shellcheck, markdown, and release automation.                                                           |
 
 Template and extension data is maintained in [`Create-Node-App/cna-templates`](https://github.com/Create-Node-App/cna-templates). This repo consumes that catalog remotely.
@@ -182,7 +182,7 @@ npx create-awesome-node-app local-app \
 ## Quality Checks
 
 | Command                 | What it validates                                          |
-| ----------------------- | ---------------------------------------------------------- |
+|-------------------------|------------------------------------------------------------|
 | `npm run build`         | Builds all packages through Turborepo.                     |
 | `npm run test`          | Runs package test tasks.                                   |
 | `npm run test:all`      | Runs all Node native test files under `packages/**/tests`. |
@@ -256,7 +256,7 @@ npx create-awesome-node-app --template react-vite-boilerplate --list-addons
 Common template slugs:
 
 | Slug                              | Description                                                                                           |
-| --------------------------------- | ----------------------------------------------------------------------------------------------------- |
+|-----------------------------------|-------------------------------------------------------------------------------------------------------|
 | `react-vite-boilerplate`          | React + Vite + TypeScript starter.                                                                    |
 | `nextjs-starter`                  | Production-ready Next.js starter.                                                                     |
 | `nextjs-saas-ai-starter`          | Multi-tenant SaaS starter with AI, Auth.js, Drizzle, PostgreSQL, Tailwind, shadcn/ui, RBAC, and i18n. |
@@ -271,7 +271,7 @@ Common template slugs:
 Common addon slugs:
 
 | Category       | Examples                                                                         |
-| -------------- | -------------------------------------------------------------------------------- |
+|----------------|----------------------------------------------------------------------------------|
 | UI             | `tailwind-css`, `material-ui`, `shadcn-ui`, `nextjs-shadcn`                      |
 | State and data | `zustand`, `jotai`, `tanstack-react-query`, `apollo-client`                      |
 | Backend and DB | `drizzle-orm-postgresql`, `drizzle-orm-sqlite`, `mongoose-orm-mongodb`           |

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -5,12 +5,12 @@ CLI versions relate to template content.
 
 ## Runtime requirements
 
-| Component        | Requirement  | Where it is declared                              |
-|------------------|--------------|---------------------------------------------------|
-| Node.js (CLI)    | `>= 22.0.0`  | `packages/create-awesome-node-app/package.json`   |
-| Node.js (repo)   | `>= 24.17.0` | Root `package.json` (development only)            |
-| npm (repo/CI)    | `>= 11.13.0` | Root `package.json` (development only)            |
-| npm (CI images)  | 11.x         | `.github/workflows/ci-*.yml` pin `npm@11`         |
+| Component       | Requirement  | Where it is declared                            |
+|-----------------|--------------|-------------------------------------------------|
+| Node.js (CLI)   | `>= 22.0.0`  | `packages/create-awesome-node-app/package.json` |
+| Node.js (repo)  | `>= 24.17.0` | Root `package.json` (development only)          |
+| npm (repo/CI)   | `>= 11.13.0` | Root `package.json` (development only)          |
+| npm (CI images) | 11.x         | `.github/workflows/ci-*.yml` pin `npm@11`       |
 
 Notes:
 
@@ -25,13 +25,13 @@ Notes:
 
 ## Distribution
 
-| Channel  | Notes                                                        |
-|----------|--------------------------------------------------------------|
-| npm      | `create-awesome-node-app` (versioned via changesets)         |
-| Homebrew | `Create-Node-App/tap`; requires Homebrew 4.x-compatible     |
-|          | formula (no `Language::Node.std_npm_args`, removed in 4.x)   |
-| AUR      | Community package, synced from npm releases                  |
-| Docker   | Published alongside releases                                 |
+| Channel  | Notes                                                      |
+|----------|------------------------------------------------------------|
+| npm      | `create-awesome-node-app` (versioned via changesets)       |
+| Homebrew | `Create-Node-App/tap`; requires Homebrew 4.x-compatible    |
+|          | formula (no `Language::Node.std_npm_args`, removed in 4.x) |
+| AUR      | Community package, synced from npm releases                |
+| Docker   | Published alongside releases                               |
 
 There are no GitHub Releases — npm is the source of truth for versions.
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,51 @@
+# Compatibility
+
+Runtime and distribution requirements for `create-awesome-node-app`, plus how
+CLI versions relate to template content.
+
+## Runtime requirements
+
+| Component        | Requirement  | Where it is declared                              |
+|------------------|--------------|---------------------------------------------------|
+| Node.js (CLI)    | `>= 22.0.0`  | `packages/create-awesome-node-app/package.json`   |
+| Node.js (repo)   | `>= 24.17.0` | Root `package.json` (development only)            |
+| npm (repo/CI)    | `>= 11.13.0` | Root `package.json` (development only)            |
+| npm (CI images)  | 11.x         | `.github/workflows/ci-*.yml` pin `npm@11`         |
+
+Notes:
+
+- The **published CLI runs on Node 22+**. The stricter Node 24 / npm 11
+  floor applies to **developing this repo**, not to end users.
+- npm 11 is required in CI because npm 10's arborist crashes with
+  `Cannot read properties of null (reading 'edgesOut')` on vitest 4 and
+  on workspace templates such as `turborepo-starter`
+  ([cna-templates#408](https://github.com/Create-Node-App/cna-templates/issues/408)).
+  End users on npm 10 may hit the same crash when scaffolding those
+  templates — upgrading npm (`npm install -g npm@11`) fixes it.
+
+## Distribution
+
+| Channel  | Notes                                                        |
+|----------|--------------------------------------------------------------|
+| npm      | `create-awesome-node-app` (versioned via changesets)         |
+| Homebrew | `Create-Node-App/tap`; requires Homebrew 4.x-compatible     |
+|          | formula (no `Language::Node.std_npm_args`, removed in 4.x)   |
+| AUR      | Community package, synced from npm releases                  |
+| Docker   | Published alongside releases                                 |
+
+There are no GitHub Releases — npm is the source of truth for versions.
+
+## CLI ↔ templates versioning
+
+- The CLI resolves the template/extension catalog from
+  [`cna-templates`](https://github.com/Create-Node-App/cna-templates)
+  `main` at scaffold time (subject to the on-disk cache).
+- Template content is **not pinned** to CLI versions. For reproducible
+  scaffolds, pin a ref explicitly:
+
+```bash
+create-awesome-node-app my-app --template react-vite-starter --pin <sha-or-tag>
+```
+
+- The reverse is also true: template changes (new extensions, dependency
+  bumps) take effect for all CLI versions without a CLI release.


### PR DESCRIPTION
Step 5: Node/npm floors (22 vs 24 dev), npm 11 edgesOut rationale, Homebrew 4.x, no-GH-releases note, and CLI-live-catalog versioning with --pin. Links README docs row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added compatibility guidance covering runtime and distribution requirements.
  - Documented supported Node.js and npm versions for CLI usage, development, and CI.
  - Listed available distribution channels, including npm, Homebrew, AUR, and Docker.
  - Clarified how CLI releases relate to template content.
  - Updated the repository map to link to the new compatibility documentation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->