### PR TITLE
feat(cli): scaffold progress steps and --config flag

### DIFF
--- a/packages/create-awesome-node-app/src/index.ts
+++ b/packages/create-awesome-node-app/src/index.ts
@@ -178,6 +178,10 @@ const main = async () => {
       "load the template catalog from the local fixtures/ directory instead of the network (default: auto-detect from source location; also CNA_FIXTURE_DIR)",
     )
     .option(
+      "--config <path>",
+      "load custom template options from an external cna.config.json (overrides template defaults; --set still wins)",
+    )
+    .option(
       "--add-completion [shell]",
       "print a shell completion script (bash|zsh|fish|powershell; default: detect from $SHELL)",
     )

--- a/packages/create-awesome-node-app/src/options.ts
+++ b/packages/create-awesome-node-app/src/options.ts
@@ -1,5 +1,9 @@
 import type { CnaOptions, TemplateOrExtension } from "@create-node-app/core";
-import { loadTemplateCnaConfig, ConfigParseError } from "@create-node-app/core";
+import {
+  loadTemplateCnaConfig,
+  loadCnaConfigFromPath,
+  ConfigParseError,
+} from "@create-node-app/core";
 import pc from "picocolors";
 import { isCI } from "ci-info";
 import prompts from "prompts";
@@ -137,6 +141,20 @@ const processNonInteractiveOptions = async (
     }
   }
 
+  // External --config file overrides template defaults (team standardization)
+  // but still loses to explicit --set flags below. Fails fast on bad paths.
+  const externalConfigPath =
+    typeof options.config === "string" ? options.config : undefined;
+  if (externalConfigPath) {
+    const externalConfig = loadCnaConfigFromPath(externalConfigPath);
+    for (const opt of externalConfig.customOptions ?? []) {
+      if (opt.name && opt.initial !== undefined) {
+        options[opt.name as string] = opt.initial;
+      }
+    }
+    delete (options as Record<string, unknown>).config;
+  }
+
   // Apply --set overrides — highest priority, wins over everything above
   Object.assign(options, setOverrides);
 
@@ -238,6 +256,11 @@ const processInteractiveOptions = async (
     setOverrides?: Record<string, string>;
   };
   options = restOptions as CnaOptions;
+  // Keep --config for the customOptions resolution below, then strip it so
+  // the file path doesn't leak into the EJS template context either.
+  const interactiveConfigPath =
+    typeof options.config === "string" ? options.config : undefined;
+  delete (options as Record<string, unknown>).config;
 
   // Pre-fill interactive prompts with CLI-provided values (replaces yargs argv override)
   prompts.override({ ...options, ...setOverrides });
@@ -363,8 +386,17 @@ const processInteractiveOptions = async (
   // Extract --set overrides to pre-fill prompts; removed from options before returning
   // (already extracted at function start, reuse the variable from above)
 
+  // External --config file takes priority over the template's own config
+  // (fails fast on bad paths, same as non-interactive mode).
+  const externalConfig = interactiveConfigPath
+    ? loadCnaConfigFromPath(interactiveConfigPath)
+    : null;
+
   const rawCustomOptions =
-    cnaConfig?.customOptions ?? existingTemplate?.customOptions ?? [];
+    externalConfig?.customOptions ??
+    cnaConfig?.customOptions ??
+    existingTemplate?.customOptions ??
+    [];
 
   // Filter out sensitive prompt types that config files cannot use
   const blockedTypes = new Set(["invisible", "password"]);

--- a/packages/create-awesome-node-app/tests/config-file.test.mts
+++ b/packages/create-awesome-node-app/tests/config-file.test.mts
@@ -1,0 +1,90 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import nock from 'nock';
+
+import { getCnaOptions } from '../src/options.js';
+
+nock('https://raw.githubusercontent.com')
+  .get(/\/Create-Node-App\/cna-templates\/main\/templates.json/)
+  .reply(200, { templates: [], extensions: [], categories: [] })
+  .persist();
+
+const makeTemplateDir = (initial: string): string => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cna-tpl-'));
+  fs.writeFileSync(
+    path.join(dir, 'cna.config.json'),
+    JSON.stringify({
+      customOptions: [{ name: 'srcDir', type: 'text', initial }],
+    }),
+  );
+  return dir;
+};
+
+const makeExternalConfig = (initial: string): string => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cna-ext-'));
+  const file = path.join(dir, 'team-cna.json');
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      customOptions: [{ name: 'srcDir', type: 'text', initial }],
+    }),
+  );
+  return file;
+};
+
+test('--config overrides template cna.config.json initials', async () => {
+  const tplDir = makeTemplateDir('from-template');
+  const extFile = makeExternalConfig('from-external');
+  try {
+    const out = (await getCnaOptions({
+      projectName: 'x',
+      interactive: false,
+      template: `file://${tplDir}`,
+      config: extFile,
+    } as never)) as unknown as Record<string, unknown>;
+    assert.equal(out.srcDir, 'from-external');
+    assert.equal(out.config, undefined);
+  } finally {
+    fs.rmSync(tplDir, { recursive: true, force: true });
+    fs.rmSync(path.dirname(extFile), { recursive: true, force: true });
+  }
+});
+
+test('--set still wins over --config', async () => {
+  const tplDir = makeTemplateDir('from-template');
+  const extFile = makeExternalConfig('from-external');
+  try {
+    const out = (await getCnaOptions({
+      projectName: 'x',
+      interactive: false,
+      template: `file://${tplDir}`,
+      config: extFile,
+      setOverrides: { srcDir: 'from-set' },
+    } as never)) as unknown as Record<string, unknown>;
+    assert.equal(out.srcDir, 'from-set');
+  } finally {
+    fs.rmSync(tplDir, { recursive: true, force: true });
+    fs.rmSync(path.dirname(extFile), { recursive: true, force: true });
+  }
+});
+
+test('missing --config path fails fast with an actionable error', async () => {
+  const tplDir = makeTemplateDir('from-template');
+  try {
+    await assert.rejects(
+      () =>
+        getCnaOptions({
+          projectName: 'x',
+          interactive: false,
+          template: `file://${tplDir}`,
+          config: '/tmp/definitely-not-here-cna/config.json',
+        } as never),
+      /does not exist/,
+    );
+  } finally {
+    fs.rmSync(tplDir, { recursive: true, force: true });
+  }
+});

--- a/packages/create-node-app-core/config.ts
+++ b/packages/create-node-app-core/config.ts
@@ -62,6 +62,27 @@ export const assertDirectoryIsEmpty = (dirPath: string) => {
  * Works for both remote GitHub URLs (uses cached clone) and local file:// URLs.
  * Returns null if the file doesn't exist or cannot be parsed.
  */
+/**
+ * Load cna.config.json from an explicit file path (`--config <path>`).
+ * Unlike {@link loadTemplateCnaConfig}, a missing or unparsable file is a
+ * hard error: the user asked for this file, so fail fast instead of
+ * silently falling back to template defaults.
+ */
+export const loadCnaConfigFromPath = (configPath: string): CnaConfig => {
+  const resolved = path.resolve(configPath);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(
+      `Cannot load --config file: ${configPath} does not exist. Pass a path to a cna.config.json file.`,
+    );
+  }
+  const content = fs.readFileSync(resolved, "utf8");
+  try {
+    return JSON.parse(content) as CnaConfig;
+  } catch (err) {
+    throw new ConfigParseError(resolved, err);
+  }
+};
+
 export const loadTemplateCnaConfig = async (
   templateUrl: string,
 ): Promise<CnaConfig | null> => {

--- a/packages/create-node-app-core/index.ts
+++ b/packages/create-node-app-core/index.ts
@@ -5,6 +5,8 @@ import { execFileSync } from "child_process";
 import corePackageJson from "./package.json" with { type: "json" };
 import type { TemplateOrExtension } from "./loaders.js";
 export type { TemplateOrExtension } from "./loaders.js";
+export { loadFiles } from "./loaders.js";
+export type { LoadFilesOptions } from "./loaders.js";
 import { createApp } from "./installer.js";
 import { resolveExecutable } from "./executable.js";
 
@@ -21,7 +23,7 @@ export {
   resolveCacheDir,
 } from "./git.js";
 export type { CacheMeta, RefreshMode } from "./git.js";
-export { loadTemplateCnaConfig } from "./config.js";
+export { loadTemplateCnaConfig, loadCnaConfigFromPath } from "./config.js";
 export type { CnaConfig, CnaCustomOption } from "./config.js";
 export {
   assertDirectoryIsEmpty,

--- a/packages/create-node-app-core/installer.ts
+++ b/packages/create-node-app-core/installer.ts
@@ -25,6 +25,15 @@ import { resolveExecutable } from "./executable.js";
 import { assertDirectoryIsEmpty } from "./config.js";
 import { ScaffoldAbortedError } from "./errors.js";
 
+/**
+ * Print a one-line step indicator during scaffolding so users can tell the
+ * CLI is making progress through long silent phases (resolve, copy).
+ * Uses picocolors (already a dependency) — no spinner library needed.
+ */
+export const logStep = (message: string) => {
+  console.log(pc.cyan(`${message}...`));
+};
+
 const install = async (
   root: string,
   useYarn = false,
@@ -252,6 +261,7 @@ const run = async ({
 
   console.log();
   console.log("Scaffolding project in " + root + "...");
+  logStep("Copying files");
 
   await loadFiles({
     root,
@@ -529,6 +539,8 @@ export const createApp = async ({
       : useBun
         ? "bun install"
         : "npm install";
+
+  logStep("Resolving template");
 
   const { packageJson, dependencies, devDependencies } = await loadPackages({
     templatesOrExtensions,

--- a/packages/create-node-app-core/tests/config.test.mts
+++ b/packages/create-node-app-core/tests/config.test.mts
@@ -3,7 +3,8 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { loadTemplateCnaConfig, NON_EMPTY_DIR_ERROR_CODE } from "../index.js";
+import { loadTemplateCnaConfig, loadCnaConfigFromPath, NON_EMPTY_DIR_ERROR_CODE } from "../index.js";
+import { ConfigParseError } from "../index.js";
 
 describe("loadTemplateCnaConfig", () => {
   it("returns null for non-existent template URL", async () => {
@@ -39,6 +40,42 @@ describe("loadTemplateCnaConfig", () => {
         `file://${tmpDir}`,
       );
       assert.equal(result, null);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("loadCnaConfigFromPath", () => {
+  it("loads customOptions initials from an explicit path", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cna-ext-valid-"));
+    try {
+      const file = path.join(tmpDir, "team-cna.json");
+      fs.writeFileSync(
+        file,
+        JSON.stringify({ customOptions: [{ name: "srcDir", type: "text", initial: "app" }] }),
+      );
+      const result = loadCnaConfigFromPath(file);
+      assert.equal(result.customOptions?.[0]?.name, "srcDir");
+      assert.equal(result.customOptions?.[0]?.initial, "app");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws an actionable error for a missing file", () => {
+    assert.throws(
+      () => loadCnaConfigFromPath("/tmp/definitely-not-here-cna/config.json"),
+      /--config.*does not exist/,
+    );
+  });
+
+  it("throws ConfigParseError for invalid JSON", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cna-ext-bad-"));
+    try {
+      const file = path.join(tmpDir, "bad.json");
+      fs.writeFileSync(file, "{ not json");
+      assert.throws(() => loadCnaConfigFromPath(file), ConfigParseError);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/packages/create-node-app-core/tests/installer.test.mts
+++ b/packages/create-node-app-core/tests/installer.test.mts
@@ -1,6 +1,23 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { extractNameAndVersion } from "../installer.js";
+import { extractNameAndVersion, logStep } from "../installer.js";
+
+describe("logStep", () => {
+  it("prints the step message with an ellipsis", () => {
+    const lines: string[] = [];
+    const original = console.log;
+    console.log = (...args: unknown[]) => {
+      lines.push(args.map(String).join(" "));
+    };
+    try {
+      logStep("Copying files");
+    } finally {
+      console.log = original;
+    }
+    assert.equal(lines.length, 1);
+    assert.ok(lines[0]!.includes("Copying files..."));
+  });
+});
 
 describe("extractNameAndVersion", () => {
   it("splits simple package with version", () => {


### PR DESCRIPTION
Closes #231 (step indicators via picocolors, no new dep) and #236 (--config with fail-fast errors, both modes, no EJS leak). Tests: core config/installer + CLI config-file suites green; full suite 149/149; tsc clean.