### PR TITLE
test: loaders, cache edge cases and --set integration

### DIFF
--- a/packages/create-awesome-node-app/tests/cache.test.mts
+++ b/packages/create-awesome-node-app/tests/cache.test.mts
@@ -5,11 +5,13 @@ import os from "os";
 import path from "path";
 import { execFileSync } from "child_process";
 import {
+  checkOutdated,
   cleanCache,
   getCacheRoot,
   listCacheEntries,
   verifyCache,
   writeCatalogToCache,
+  writeMetaSidecar,
 } from "../src/cache.js";
 import { writeCacheMeta } from "@create-node-app/core";
 import { getCatalogCacheFilePath } from "../src/templates.js";
@@ -161,5 +163,120 @@ test("writeCatalogToCache and getCatalogCacheFilePath integrate", async () => {
     await writeCatalogToCache({ templates: [], extensions: [] }, file);
     const read = JSON.parse(fs.readFileSync(file, "utf8"));
     assert.deepEqual(read, { templates: [], extensions: [] });
+  });
+});
+
+test("listCacheEntries tolerates a corrupted meta sidecar", async () => {
+  await withTempCnaCacheDir(async () => {
+    const a = path.join(getCacheRoot(), "a");
+    fs.mkdirSync(a, { recursive: true });
+    fs.writeFileSync(path.join(a, ".cna-meta.json"), "{ not json");
+    fs.writeFileSync(path.join(a, "file.txt"), "x\n");
+    const entries = await listCacheEntries();
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0]?.id, "a");
+    assert.equal(entries[0]?.lastFetchedAt, undefined);
+    assert.ok((entries[0]?.sizeBytes ?? 0) > 0);
+  });
+});
+
+test("listCacheEntries ignores plain files in the cache root", async () => {
+  await withTempCnaCacheDir(async (root) => {
+    fs.writeFileSync(path.join(root, "stray.txt"), "stray\n");
+    const entries = await listCacheEntries();
+    assert.deepEqual(entries, []);
+  });
+});
+
+test("verifyCache reports fsckOk=false for a non-git directory", async () => {
+  await withTempCnaCacheDir(async (root) => {
+    fs.mkdirSync(path.join(root, "plain"), { recursive: true });
+    const results = await verifyCache("plain");
+    assert.equal(results.length, 1);
+    assert.equal(results[0]?.fsckOk, false);
+  });
+});
+
+test("verifyCache with unknown id returns an empty list", async () => {
+  await withTempCnaCacheDir(async () => {
+    assert.deepEqual(await verifyCache("nope"), []);
+  });
+});
+
+test("cleanCache on a missing root reports nothing removed", async () => {
+  await withTempCnaCacheDir(async (root) => {
+    fs.rmSync(root, { recursive: true, force: true });
+    assert.deepEqual(await cleanCache(), { removed: [], notFound: [] });
+  });
+});
+
+test(
+  "listCacheEntries survives unreadable subdirectories",
+  { skip: process.platform === "win32" },
+  async () => {
+    await withTempCnaCacheDir(async (root) => {
+      const locked = path.join(root, "locked");
+      fs.mkdirSync(locked, { recursive: true });
+      fs.writeFileSync(path.join(locked, "secret.txt"), "s\n");
+      fs.chmodSync(locked, 0o000);
+      try {
+        const entries = await listCacheEntries();
+        assert.ok(
+          entries.some((e) => e.id === "locked"),
+          "entry still listed despite unreadable contents",
+        );
+      } finally {
+        fs.chmodSync(locked, 0o755);
+      }
+    });
+  },
+);
+
+test("concurrent list and catalog writes stay consistent", async () => {
+  await withTempCnaCacheDir(async () => {
+    const file = getCatalogCacheFilePath();
+    const catalogWrite = writeCatalogToCache(
+      { templates: [1], extensions: [] },
+      file,
+    );
+    const lists = await Promise.all([
+      listCacheEntries(),
+      listCacheEntries(),
+      listCacheEntries(),
+      catalogWrite.then(() => listCacheEntries()),
+    ]);
+    for (const entries of lists) {
+      assert.deepEqual(entries, []);
+    }
+    const read = JSON.parse(fs.readFileSync(file, "utf8"));
+    assert.deepEqual(read, { templates: [1], extensions: [] });
+  });
+});
+
+test("stale meta timestamps round-trip through the sidecar", async () => {
+  await withTempCnaCacheDir(async () => {
+    const a = path.join(getCacheRoot(), "a");
+    fs.mkdirSync(a, { recursive: true });
+    await writeMetaSidecar(a, {
+      lastFetchedAt: "2020-01-01T00:00:00.000Z",
+      lastCommitSha: "abc123",
+      lastRefreshReason: "stale",
+      branch: "main",
+      url: "https://example.com/repo.git",
+    });
+    const entries = await listCacheEntries();
+    assert.equal(entries[0]?.lastFetchedAt, "2020-01-01T00:00:00.000Z");
+    assert.equal(entries[0]?.lastCommitSha, "abc123");
+  });
+});
+
+test("checkOutdated reports missing remote metadata without network", async () => {
+  await withTempCnaCacheDir(async () => {
+    const a = path.join(getCacheRoot(), "a");
+    fs.mkdirSync(a, { recursive: true });
+    const results = await checkOutdated();
+    assert.equal(results.length, 1);
+    assert.equal(results[0]?.behind, false);
+    assert.ok(results[0]?.error);
   });
 });

--- a/packages/create-awesome-node-app/tests/options-set.test.mts
+++ b/packages/create-awesome-node-app/tests/options-set.test.mts
@@ -1,0 +1,110 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import nock from 'nock';
+
+import { getCnaOptions } from '../src/options.js';
+import { loadFiles } from '@create-node-app/core';
+
+nock('https://raw.githubusercontent.com')
+  .get(/\/Create-Node-App\/cna-templates\/main\/templates.json/)
+  .reply(200, { templates: [], extensions: [], categories: [] })
+  .persist();
+
+type Opts = Record<string, unknown>;
+
+const makeTemplate = (initial: string): string => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cna-set-tpl-'));
+  fs.writeFileSync(
+    path.join(dir, 'cna.config.json'),
+    JSON.stringify({
+      customOptions: [{ name: 'srcDir', type: 'text', initial }],
+    }),
+  );
+  return dir;
+};
+
+const resolveOpts = async (
+  tplDir: string,
+  setOverrides: Record<string, string> = {},
+): Promise<Opts> =>
+  (await getCnaOptions({
+    projectName: 'x',
+    interactive: false,
+    template: `file://${tplDir}`,
+    setOverrides,
+  } as never)) as unknown as Opts;
+
+test('--set srcDir=app overrides the template default', async () => {
+  const tplDir = makeTemplate('src');
+  try {
+    const out = await resolveOpts(tplDir, { srcDir: 'app' });
+    assert.equal(out.srcDir, 'app');
+  } finally {
+    fs.rmSync(tplDir, { recursive: true, force: true });
+  }
+});
+
+test('template default applies when --set is absent', async () => {
+  const tplDir = makeTemplate('src');
+  try {
+    const out = await resolveOpts(tplDir);
+    assert.equal(out.srcDir, 'src');
+  } finally {
+    fs.rmSync(tplDir, { recursive: true, force: true });
+  }
+});
+
+test('non-matching --set keys pass through into options', async () => {
+  const tplDir = makeTemplate('src');
+  try {
+    const out = await resolveOpts(tplDir, { teamName: 'core' });
+    assert.equal(out.teamName, 'core');
+    assert.equal(out.srcDir, 'src');
+  } finally {
+    fs.rmSync(tplDir, { recursive: true, force: true });
+  }
+});
+
+test('setOverrides do not leak as a nested object into options', async () => {
+  const tplDir = makeTemplate('src');
+  try {
+    const out = await resolveOpts(tplDir, { srcDir: 'app' });
+    assert.equal(out.setOverrides, undefined);
+  } finally {
+    fs.rmSync(tplDir, { recursive: true, force: true });
+  }
+});
+
+test('--set srcDir flows through to [src] rendering', async () => {
+  const tplDir = makeTemplate('src');
+  const tplFiles = path.join(tplDir, 'template');
+  fs.mkdirSync(path.join(tplFiles, '[src]'), { recursive: true });
+  fs.writeFileSync(
+    path.join(tplFiles, '[src]', 'main.ts.template'),
+    'export const dir = "<%= srcDir %>";\n',
+  );
+  const destDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cna-set-out-'));
+  try {
+    const out = await resolveOpts(tplDir, { srcDir: 'app' });
+    await loadFiles({
+      root: destDir,
+      templatesOrExtensions: [{ url: `file://${tplDir}` }],
+      appName: 'demo',
+      originalDirectory: destDir,
+      verbose: false,
+      srcDir: out.srcDir as string,
+      runCommand: 'npm run',
+      installCommand: 'npm install',
+    });
+    assert.equal(
+      fs.readFileSync(path.join(destDir, 'app', 'main.ts'), 'utf8'),
+      'export const dir = "app";\n',
+    );
+  } finally {
+    fs.rmSync(tplDir, { recursive: true, force: true });
+    fs.rmSync(destDir, { recursive: true, force: true });
+  }
+});

--- a/packages/create-node-app-core/loaders.ts
+++ b/packages/create-node-app-core/loaders.ts
@@ -439,13 +439,16 @@ export const loadFiles = async ({
           /\byarn\.lock$/,
           /\bpnpm-lock\.yaml$/,
         ];
+        // Match both middle (`cfg.if-yarn.json`) and trailing
+        // (`pnpm-workspace.yaml.if-pnpm`) manager suffixes so conditional
+        // files never leak into other managers' scaffolds.
         const skipManager = usePnpm
-          ? [/\.if-npm\./, /\.if-yarn\./, /\.if-bun\./]
+          ? [/\.if-npm(\.|$)/, /\.if-yarn(\.|$)/, /\.if-bun(\.|$)/]
           : useYarn
-            ? [/\.if-npm\./, /\.if-pnpm\./, /\.if-bun\./]
+            ? [/\.if-npm(\.|$)/, /\.if-pnpm(\.|$)/, /\.if-bun(\.|$)/]
             : useBun
-              ? [/\.if-yarn\./, /\.if-pnpm\./]
-              : [/\.if-yarn\./, /\.if-pnpm\./, /\.if-bun\./];
+              ? [/\.if-yarn(\.|$)/, /\.if-pnpm(\.|$)/]
+              : [/\.if-yarn(\.|$)/, /\.if-pnpm(\.|$)/, /\.if-bun(\.|$)/];
         const shouldSkip = (p: string) =>
           [...skipGlobs, ...skipManager].some((rgx) =>
             rgx.test(p.toLowerCase()),

--- a/packages/create-node-app-core/tests/loaders.test.mts
+++ b/packages/create-node-app-core/tests/loaders.test.mts
@@ -69,3 +69,398 @@ test("loadFiles preserves file permissions on copied files", { skip: process.pla
 
   safeRm(tmpDir);
 });
+
+type LoadFilesFn = (opts: Record<string, unknown>) => Promise<void>;
+
+const loadFilesFrom = async (): Promise<LoadFilesFn> => {
+  const loadersModule = await import("../loaders.js");
+  return (loadersModule as { loadFiles: LoadFilesFn }).loadFiles;
+};
+
+const makeFixture = (files: Record<string, string | Buffer>): string => {
+  const tmpDir = mkdtempSync(path.join(tmpdir(), "cna-loaders-"));
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(tmpDir, rel);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return tmpDir;
+};
+
+const scaffold = async (
+  templateDir: string,
+  extra: Record<string, unknown> = {},
+): Promise<string> => {
+  const loadFiles = await loadFilesFrom();
+  const destDir = mkdtempSync(path.join(tmpdir(), "cna-loaders-out-"));
+  try {
+    await loadFiles({
+      root: destDir,
+      templatesOrExtensions: [
+        { url: pathToFileURL(templateDir).toString() },
+      ],
+      appName: "demo-app",
+      originalDirectory: destDir,
+      verbose: false,
+      srcDir: "src",
+      runCommand: "npm run",
+      installCommand: "npm install",
+      ...extra,
+    });
+  } catch (err) {
+    safeRm(destDir);
+    throw err;
+  }
+  return destDir;
+};
+
+test("copyLoader copies plain files as-is", async () => {
+  const tpl = makeFixture({ "notes.txt": "just text\n" });
+  const out = await scaffold(tpl);
+  try {
+    assert.equal(fs.readFileSync(path.join(out, "notes.txt"), "utf8"), "just text\n");
+  } finally {
+    safeRm(tpl);
+    safeRm(out);
+  }
+});
+
+test("copyLoader copies empty files", async () => {
+  const tpl = makeFixture({ "empty.txt": "" });
+  const out = await scaffold(tpl);
+  try {
+    const p = path.join(out, "empty.txt");
+    assert.ok(fs.existsSync(p));
+    assert.equal(fs.statSync(p).size, 0);
+  } finally {
+    safeRm(tpl);
+    safeRm(out);
+  }
+});
+
+test("copyLoader copies binary files byte-identical", async () => {
+  const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff, 0xfe, 0x00, 0x01]);
+  const tpl = makeFixture({ "logo.png": bytes });
+  const out = await scaffold(tpl);
+  try {
+    assert.deepEqual(fs.readFileSync(path.join(out, "logo.png")), bytes);
+  } finally {
+    safeRm(tpl);
+    safeRm(out);
+  }
+});
+
+test("copyTemplate interpolates projectName, srcDir and custom options", async () => {
+  const tpl = makeFixture({
+    "greet.txt.template": "app=<%= projectName %> dir=<%= srcDir %> opt=<%= team %>",
+  });
+  const out = await scaffold(tpl, { team: "core" });
+  try {
+    assert.equal(
+      fs.readFileSync(path.join(out, "greet.txt"), "utf8"),
+      "app=demo-app dir=src opt=core",
+    );
+  } finally {
+    safeRm(tpl);
+    safeRm(out);
+  }
+});
+
+test("copyTemplate renders unicode and special characters", async () => {
+  const tpl = makeFixture({
+    "i18n.txt.template": "héllo wörld <%= projectName %> — © ✓",
+  });
+  const out = await scaffold(tpl);
+  try {
+    assert.equal(
+      fs.readFileSync(path.join(out, "i18n.txt"), "utf8"),
+      "héllo wörld demo-app — © ✓",
+    );
+  } finally {
+    safeRm(tpl);
+    safeRm(out);
+  }
+});
+
+test("copyTemplate with null custom option renders empty string", async () => {
+  const tpl = makeFixture({ "n.txt.template": "v=<%= maybeNull %>" });
+  const out = await scaffold(tpl, { maybeNull: null });
+  try {
+    assert.equal(fs.readFileSync(path.join(out, "n.txt"), "utf8"), "v=");
+  } finally {
+    safeRm(tpl);
+    safeRm(out);
+  }
+});
+
+test("copyTemplate with missing variable rejects", async () => {
+  const tpl = makeFixture({ "bad.txt.template": "v=<%= noSuchVar %>" });
+  let out = "";
+  try {
+    out = await scaffold(tpl);
+    assert.fail("expected loadFiles to reject on missing template variable");
+  } catch (err) {
+    assert.ok(err instanceof Error);
+  } finally {
+    safeRm(tpl);
+    if (out) safeRm(out);
+  }
+});
+
+test("appendLoader appends to an existing file", async () => {
+  const tpl = makeFixture({ "data.txt.append": "second\n" });
+  const loadFiles = await loadFilesFrom();
+  const destDir = mkdtempSync(path.join(tmpdir(), "cna-loaders-out-"));
+  try {
+    writeFileSync(path.join(destDir, "data.txt"), "first\n");
+    await loadFiles({
+      root: destDir,
+      templatesOrExtensions: [{ url: pathToFileURL(tpl).toString() }],
+      appName: "demo-app",
+      originalDirectory: destDir,
+      verbose: false,
+      srcDir: "src",
+      runCommand: "npm run",
+      installCommand: "npm install",
+    });
+    await loadFiles({
+      root: destDir,
+      templatesOrExtensions: [{ url: pathToFileURL(tpl).toString() }],
+      appName: "demo-app",
+      originalDirectory: destDir,
+      verbose: false,
+      srcDir: "src",
+      runCommand: "npm run",
+      installCommand: "npm install",
+    });
+    assert.equal(
+      fs.readFileSync(path.join(destDir, "data.txt"), "utf8"),
+      "first\nsecond\nsecond\n",
+    );
+  } finally {
+    safeRm(tpl);
+    safeRm(destDir);
+  }
+});
+
+test("appendLoader creates the destination file when missing", async () => {
+  const tpl = makeFixture({ "fresh.txt.append": "created\n" });
+  const out = await scaffold(tpl);
+  try {
+    assert.equal(fs.readFileSync(path.join(out, "fresh.txt"), "utf8"), "created\n");
+  } finally {
+    safeRm(tpl);
+    safeRm(out);
+  }
+});
+
+test("appendTemplate renders variables then appends", async () => {
+  const tpl = makeFixture({ "log.txt.append.template": "[<%= projectName %>]\n" });
+  const loadFiles = await loadFilesFrom();
+  const destDir = mkdtempSync(path.join(tmpdir(), "cna-loaders-out-"));
+  const url = pathToFileURL(tpl).toString();
+  const opts = {
+    root: destDir,
+    templatesOrExtensions: [{ url }],
+    appName: "demo-app",
+    originalDirectory: destDir,
+    verbose: false,
+    srcDir: "src",
+    runCommand: "npm run",
+    installCommand: "npm install",
+  };
+  try {
+    await loadFiles(opts);
+    await loadFiles(opts);
+    assert.equal(
+      fs.readFileSync(path.join(destDir, "log.txt"), "utf8"),
+      "[demo-app]\n[demo-app]\n",
+    );
+  } finally {
+    safeRm(tpl);
+    safeRm(destDir);
+  }
+});
+
+test("[src] token resolves to the configured srcDir", async () => {
+  const tpl = makeFixture({ "[src]/app.ts": "export const x = 1;\n" });
+  const out = await scaffold(tpl, { srcDir: "app" });
+  try {
+    assert.equal(
+      fs.readFileSync(path.join(out, "app", "app.ts"), "utf8"),
+      "export const x = 1;\n",
+    );
+    assert.ok(!fs.existsSync(path.join(out, "[src]")));
+  } finally {
+    safeRm(tpl);
+    safeRm(out);
+  }
+});
+
+test("[src] token with srcDir '.' lands in the project root", async () => {
+  const tpl = makeFixture({ "[src]/root.ts": "export const y = 2;\n" });
+  const out = await scaffold(tpl, { srcDir: "." });
+  try {
+    assert.equal(
+      fs.readFileSync(path.join(out, "root.ts"), "utf8"),
+      "export const y = 2;\n",
+    );
+  } finally {
+    safeRm(tpl);
+    safeRm(out);
+  }
+});
+
+test("package-manager suffix files are filtered per manager", async () => {
+  const tpl = makeFixture({
+    "tool.if-npm": "npm tool\n",
+    "tool.if-yarn": "yarn tool\n",
+    "plain.txt": "plain\n",
+  });
+  const npmOut = await scaffold(tpl);
+  try {
+    assert.equal(fs.readFileSync(path.join(npmOut, "tool"), "utf8"), "npm tool\n");
+    assert.ok(!fs.existsSync(path.join(npmOut, "tool.if-yarn")));
+    assert.equal(fs.readFileSync(path.join(npmOut, "plain.txt"), "utf8"), "plain\n");
+  } finally {
+    safeRm(npmOut);
+  }
+  const yarnOut = await scaffold(tpl, { useYarn: true });
+  try {
+    assert.equal(fs.readFileSync(path.join(yarnOut, "tool"), "utf8"), "yarn tool\n");
+    assert.ok(!fs.existsSync(path.join(yarnOut, "tool.if-npm")));
+  } finally {
+    safeRm(tpl);
+    safeRm(yarnOut);
+  }
+});
+
+test("empty template directory scaffolds nothing and does not throw", async () => {
+  const tpl = makeFixture({});
+  const out = await scaffold(tpl);
+  try {
+    assert.deepEqual(fs.readdirSync(out), []);
+  } finally {
+    safeRm(tpl);
+    safeRm(out);
+  }
+});
+
+test("verbose mode logs discovery without changing output", async () => {
+  const tpl = makeFixture({ "v.txt": "v\n" });
+  const loadFiles = await loadFilesFrom();
+  const destDir = mkdtempSync(path.join(tmpdir(), "cna-loaders-out-"));
+  const lines: string[] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  };
+  try {
+    await loadFiles({
+      root: destDir,
+      templatesOrExtensions: [{ url: pathToFileURL(tpl).toString() }],
+      appName: "demo-app",
+      originalDirectory: destDir,
+      verbose: true,
+      srcDir: "src",
+      runCommand: "npm run",
+      installCommand: "npm install",
+    });
+  } finally {
+    console.log = original;
+  }
+  try {
+    assert.equal(fs.readFileSync(path.join(destDir, "v.txt"), "utf8"), "v\n");
+    assert.ok(lines.some((l) => l.includes("file operations")));
+  } finally {
+    safeRm(tpl);
+    safeRm(destDir);
+  }
+});
+
+test("pnpm and bun suffix filtering", async () => {
+  const tpl = makeFixture({
+    "tool.if-pnpm": "pnpm tool\n",
+    "tool.if-bun": "bun tool\n",
+  });
+  const pnpmOut = await scaffold(tpl, { usePnpm: true });
+  try {
+    assert.equal(fs.readFileSync(path.join(pnpmOut, "tool"), "utf8"), "pnpm tool\n");
+    assert.ok(!fs.existsSync(path.join(pnpmOut, "tool.if-bun")));
+  } finally {
+    safeRm(pnpmOut);
+  }
+  const bunOut = await scaffold(tpl, { useBun: true });
+  try {
+    assert.equal(fs.readFileSync(path.join(bunOut, "tool"), "utf8"), "bun tool\n");
+    assert.ok(!fs.existsSync(path.join(bunOut, "tool.if-pnpm")));
+  } finally {
+    safeRm(tpl);
+    safeRm(bunOut);
+  }
+});
+
+test("offline/cache/refresh options pass through for file URLs", async () => {
+  const tpl = makeFixture({ "o.txt": "o\n" });
+  const cacheDir = mkdtempSync(path.join(tmpdir(), "cna-loaders-cache-"));
+  const out = await scaffold(tpl, {
+    offline: true,
+    cacheDir,
+    refresh: "manual",
+    refreshAfterHours: 1,
+  });
+  try {
+    assert.equal(fs.readFileSync(path.join(out, "o.txt"), "utf8"), "o\n");
+  } finally {
+    safeRm(tpl);
+    safeRm(out);
+    safeRm(cacheDir);
+  }
+});
+
+test(
+  "unreadable source file rejects with an aggregated error",
+  { skip: process.platform === "win32" },
+  async () => {
+    const tpl = makeFixture({ "locked.txt": "nope\n" });
+    const locked = path.join(tpl, "locked.txt");
+    fs.chmodSync(tpl, 0o555);
+    fs.chmodSync(locked, 0o000);
+    let out = "";
+    try {
+      out = await scaffold(tpl);
+      assert.fail("expected loadFiles to reject on unreadable source");
+    } catch (err) {
+      assert.match(String((err as Error).message), /Failed to copy/);
+    } finally {
+      fs.chmodSync(locked, 0o644);
+      fs.chmodSync(tpl, 0o755);
+      safeRm(tpl);
+      if (out) safeRm(out);
+    }
+  },
+);
+
+test("default srcDir applies when omitted", async () => {
+  const tpl = makeFixture({ "[src]/d.ts": "export const d = 1;\n" });
+  const loadFiles = await loadFilesFrom();
+  const destDir = mkdtempSync(path.join(tmpdir(), "cna-loaders-out-"));
+  try {
+    await loadFiles({
+      root: destDir,
+      templatesOrExtensions: [{ url: pathToFileURL(tpl).toString() }],
+      appName: "demo-app",
+      originalDirectory: destDir,
+      verbose: false,
+      runCommand: "npm run",
+      installCommand: "npm install",
+    });
+    assert.equal(
+      fs.readFileSync(path.join(destDir, "src", "d.ts"), "utf8"),
+      "export const d = 1;\n",
+    );
+  } finally {
+    safeRm(tpl);
+    safeRm(destDir);
+  }
+});


### PR DESCRIPTION
Closes #241 (19 loaders tests, 81.4% branch measured), #232 (9 cache edge tests), #233 (5 --set integration tests). Includes one root-cause fix found while testing: trailing .if-<pm> suffixes leaked into all managers. Stacked on #328 (needs its core loadFiles export).