### PR TITLE
ci: add yarn/pnpm scaffold matrix job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,6 +89,62 @@ jobs:
           CNA_SKIP_GIT: 1
           CI: true
 
+  # Package-manager scaffold matrix (yarn, pnpm) — bun is covered by the
+  # bun-scaffold job above. Uses --no-install so the job tests scaffold
+  # filtering/wiring per manager without slow registry installs.
+  pm-scaffold:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pm: [yarn, pnpm]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Enable corepack (${{ matrix.pm }})
+        run: corepack enable
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test scaffold with ${{ matrix.pm }} (react-vite-boilerplate)
+        shell: bash
+        run: |
+          TEMP_DIR="${RUNNER_TEMP}/${{ matrix.pm }}-scaffold-test"
+          mkdir -p "$TEMP_DIR"
+          cd "$TEMP_DIR"
+
+          CLI="$GITHUB_WORKSPACE/packages/create-awesome-node-app/index.js"
+          echo "Testing scaffold with ${{ matrix.pm }} using react-vite-boilerplate..."
+          CI=true node "$CLI" test-project \
+            --template react-vite-boilerplate \
+            --use-${{ matrix.pm }} \
+            --no-interactive \
+            --no-install
+
+          if [ -d "test-project" ]; then
+            echo "✅ Project created successfully with ${{ matrix.pm }} (react-vite-boilerplate)"
+          else
+            echo "❌ Project creation failed with ${{ matrix.pm }} (react-vite-boilerplate)"
+            exit 1
+          fi
+        env:
+          CNA_SKIP_GIT: 1
+          CI: true
+
   # Cross-platform scaffolding tests (Node on Windows/macOS, Bun on Ubuntu)
   cross-platform-scaffold:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false


### PR DESCRIPTION
Closes #237. New pm-scaffold job (yarn, pnpm) via corepack, --no-install scaffold of react-vite-boilerplate. Bun stays covered by bun-scaffold; YAML validated locally.