### PR TITLE
fix(release): build dist before publishing version bumps

### DIFF
--- a/.changeset/packaging-dist-fix.md
+++ b/.changeset/packaging-dist-fix.md
@@ -1,0 +1,5 @@
+---
+'create-awesome-node-app': patch
+---
+
+Fix release packaging: build dist before publishing so the npm tarball contains the compiled CLI (0.17.0 shipped console-only files and crashed on startup).

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,6 +89,10 @@ jobs:
             npm run publish-packages
           else
             echo "No unreleased changesets found, checking for new versions to publish"
+            # dist/ is gitignored, so a bare `changeset publish` would ship
+            # tarballs without build output (see the empty 0.17.0). Always
+            # build first — publish stays a safe no-op when nothing is new.
+            npm run build
             npx changeset publish || echo "No new versions to publish, skipping"
           fi
 


### PR DESCRIPTION
0.17.0 shipped without dist/ (bare changeset publish on a gitignored build dir) and crashes on startup. Build first; publish stays a safe no-op otherwise. Includes patch changeset → 0.17.1.