### PR TITLE
chore: changeset for core dist republish

### DIFF
--- a/.changeset/core-dist-republish.md
+++ b/.changeset/core-dist-republish.md
@@ -1,0 +1,5 @@
+---
+'@create-node-app/core': patch
+---
+
+Republish with compiled dist output (0.10.0 shipped metadata-only files, so installs missed the entire build).


### PR DESCRIPTION
Patch bump to force republication of @create-node-app/core with dist/ (0.10.0 shipped metadata-only).