### PR TITLE
fix(core): skip extension bank-only root files to prevent README race

### DIFF
--- a/packages/create-node-app-core/loaders.ts
+++ b/packages/create-node-app-core/loaders.ts
@@ -401,7 +401,10 @@ export const loadFiles = async ({
 }: LoadFilesOptions) => {
   try {
     const operations = [];
+    let templateOrExtensionIndex = 0;
     for await (const { url: templateOrExtensionUrl } of templatesOrExtensions) {
+      const isExtension = templateOrExtensionIndex > 0;
+      templateOrExtensionIndex += 1;
       const templateDir = await getTemplateDirPath(templateOrExtensionUrl, {
         ...(offline !== undefined ? { offline } : {}),
         ...(cacheDir !== undefined ? { cacheDir } : {}),
@@ -454,12 +457,35 @@ export const loadFiles = async ({
             rgx.test(p.toLowerCase()),
           );
 
+        // Bank-only docs at the extension root are never scaffolded
+        // (cna-templates#396). Every extension ships `README.md` as bank
+        // documentation while the base template owns the generated
+        // project's top-level README; without this filter both writers
+        // race on `<root>/README.md` via `Promise.allSettled`. Only the
+        // root level is filtered so intentional payloads such as
+        // `docs/README.md.append` still merge.
+        const isBankOnlyRootFile = (p: string) => {
+          if (!isExtension) return false;
+          if (p.includes("/")) return false;
+          return /^(readme\.md|license(\.md|\.txt)?|contributing(\.md)?)$/i.test(
+            p,
+          );
+        };
+
         for await (const entry of readdirp(templateDir, {
           type: "files",
           alwaysStat: false,
         })) {
           if (shouldSkip(entry.path)) continue;
           if (entry.path.startsWith("package/")) continue; // skip helper package dir
+          if (isBankOnlyRootFile(entry.path)) {
+            if (verbose) {
+              console.log(
+                pc.dim(`[cna] Skipping bank-only file: ${entry.path}`),
+              );
+            }
+            continue;
+          }
           if (verbose && debugFirst) {
             console.log(pc.dim(`[cna] First discovered file: ${entry.path}`));
             debugFirst = false;

--- a/packages/create-node-app-core/tests/loaders.test.mts
+++ b/packages/create-node-app-core/tests/loaders.test.mts
@@ -464,3 +464,41 @@ test("default srcDir applies when omitted", async () => {
     safeRm(destDir);
   }
 });
+
+test("extension bank-only root files never overwrite the template README", async () => {
+  const tpl = makeFixture({ "README.md": "# Template\n" });
+  const ext = makeFixture({
+    "README.md": "# Bank docs (must not leak)\n",
+    "LICENSE.md": "bank license\n",
+    "docs/notes.md": "keep me\n",
+  });
+  const loadFiles = await loadFilesFrom();
+  const destDir = mkdtempSync(path.join(tmpdir(), "cna-loaders-out-"));
+  try {
+    await loadFiles({
+      root: destDir,
+      templatesOrExtensions: [
+        { url: pathToFileURL(tpl).toString() },
+        { url: pathToFileURL(ext).toString() },
+      ],
+      appName: "demo-app",
+      originalDirectory: destDir,
+      verbose: false,
+      runCommand: "npm run",
+      installCommand: "npm install",
+    });
+    assert.equal(
+      fs.readFileSync(path.join(destDir, "README.md"), "utf8"),
+      "# Template\n",
+    );
+    assert.equal(
+      fs.readFileSync(path.join(destDir, "docs", "notes.md"), "utf8"),
+      "keep me\n",
+    );
+    assert.ok(!fs.existsSync(path.join(destDir, "LICENSE.md")));
+  } finally {
+    safeRm(tpl);
+    safeRm(ext);
+    safeRm(destDir);
+  }
+});


### PR DESCRIPTION
Closes Create-Node-App/cna-templates#396

## Summary
Extensions ship `README.md` as bank docs while the base template owns the generated project's README. `loadFiles` copied both and they raced on `<root>/README.md` via `Promise.allSettled` (reproduced: extension `react-tailwindcss/README.md` listed as COPY by the loader skip logic, colliding with `template/README.md.template` output).

## Change
- `packages/create-node-app-core/loaders.ts`: track template/extension index; for entries with index > 0 (extensions) skip root-level bank-only files `README.md`, `LICENSE`(`.md|`.txt`), `CONTRIBUTING.md` (case-insensitive, root level only so `docs/README.md.append` and other nested payloads still merge). Verbose logs the skip.
- `packages/create-node-app-core/tests/loaders.test.mts`: new test proving template README wins, nested extension docs still copy, and extension LICENSE is dropped.

## Safety
Narrow filter: base template (index 0) unaffected, nested extension files unaffected, existing permission/suffix tests untouched. Single-architecture note: CNA extensions stay flat; the loader enforces the bank-only boundary instead of migrating 53 extensions to a template/ overlay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented documentation files from extension templates from overwriting or adding unwanted root-level files.
  * Preserved nested extension files during template creation.
* **Tests**
  * Added coverage to verify correct handling of extension template files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->