### PR TITLE
chore: changeset for README race fix (#342 follow-up)

### DIFF
--- a/.changeset/tidy-pandas-fix.md
+++ b/.changeset/tidy-pandas-fix.md
@@ -1,0 +1,5 @@
+---
+'@create-node-app/core': patch
+---
+
+Skip extension bank-only root files in loadFiles to prevent README race with the base template output.


### PR DESCRIPTION
Adds the patch changeset for #342 (merged without one), so the fix ships in release notes with the next Version Packages run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a project generation issue that could cause a README file conflict when using extension bank-only root files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->